### PR TITLE
Fix ShowStats.lua hardcoded model names for non-Ollama modes

### DIFF
--- a/lrcembedindex.lrplugin/ShowStats.lua
+++ b/lrcembedindex.lrplugin/ShowStats.lua
@@ -38,15 +38,19 @@ local function showStats()
         if cfg.vision_mode == "ollama" then
             table.insert( lines, "  Endpoint: " .. ( cfg.ollama_vision_endpoint or "?" ) )
             table.insert( lines, "  Model: " .. ( cfg.ollama_vision_model or "?" ) )
+        elseif cfg.vision_mode == "claude" then
+            table.insert( lines, "  Model: " .. ( cfg.claude_vision_model or "?" ) .. " (Claude)" )
         else
-            table.insert( lines, "  Model: gpt-4o (OpenAI)" )
+            table.insert( lines, "  Model: " .. ( cfg.openai_vision_model or "?" ) .. " (OpenAI)" )
         end
         table.insert( lines, "Embed mode: " .. ( cfg.embed_mode or "?" ) )
         if cfg.embed_mode == "ollama" then
             table.insert( lines, "  Endpoint: " .. ( cfg.ollama_embed_endpoint or "?" ) )
             table.insert( lines, "  Model: " .. ( cfg.ollama_embed_model or "?" ) )
+        elseif cfg.embed_mode == "voyage" then
+            table.insert( lines, "  Model: " .. ( cfg.voyage_embed_model or "?" ) .. " (Voyage AI)" )
         else
-            table.insert( lines, "  Model: text-embedding-3-small (OpenAI)" )
+            table.insert( lines, "  Model: " .. ( cfg.openai_embed_model or "?" ) .. " (OpenAI)" )
         end
         table.insert( lines, "Search max results: " .. ( cfg.search_max_results or "?" ) )
         table.insert( lines, "Relevance threshold: " .. ( cfg.search_relevance or "?" ) )


### PR DESCRIPTION
## Summary
- Display the actual configured model name for Claude vision and Voyage AI embedding backends
- Previously hardcoded to "gpt-4o (OpenAI)" and "text-embedding-3-small (OpenAI)" for all non-Ollama modes

## Test plan
- [ ] With `vision_mode=claude`: stats show the configured Claude model with "(Claude)" label
- [ ] With `vision_mode=openai`: stats show the configured OpenAI model with "(OpenAI)" label
- [ ] With `embed_mode=voyage`: stats show the configured Voyage model with "(Voyage AI)" label
- [ ] With `embed_mode=openai`: stats show the configured OpenAI model with "(OpenAI)" label
- [ ] Ollama mode unchanged

Fixes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)