### PR TITLE
Extract shared Lua utilities to eliminate 3x code duplication

### DIFF
--- a/lrcembedindex.lrplugin/BatchDescribe.lua
+++ b/lrcembedindex.lrplugin/BatchDescribe.lua
@@ -7,6 +7,7 @@ local LrPrefs = import 'LrPrefs'
 local LrLogger = import 'LrLogger'
 
 local json = require 'dkjson'
+local utils = require 'LrCEmbedUtils'
 
 local logger = LrLogger( 'LrCEmbedIndex' )
 logger:enable( "logfile" )
@@ -58,64 +59,13 @@ local function batchDescribe()
             progress:setPortionComplete( i - 1, #allPhotos )
             progress:setCaption( "Describing photo " .. i .. " of " .. #allPhotos )
 
-            -- Request JPEG thumbnail
-            local thumbnailPixels = nil
-            local thumbnailErr = nil
-            local done = false
-
-            local width = photo:getRawMetadata( "width" )
-            local height = photo:getRawMetadata( "height" )
-            if width and height then
-                width = math.min( width / 2, 1024 )
-                height = math.min( height / 2, 1024 )
-            else
-                width = 1024
-                height = 1024
-            end
-
-            local request = photo:requestJpegThumbnail( width, height, function( pixels, errMsg )
-                thumbnailPixels = pixels
-                thumbnailErr = errMsg
-                done = true
-            end )
-
-            -- Wait for thumbnail (up to 30 seconds)
-            local waitCount = 0
-            while not done and waitCount < 300 do
-                LrTasks.sleep( 0.1 )
-                waitCount = waitCount + 1
-            end
+            local thumbnailPixels, thumbnailErr = utils.requestThumbnail( photo )
 
             if thumbnailPixels and not thumbnailErr then
                 local imagePath = photo:getRawMetadata( "path" ) or ""
 
-                -- Collect EXIF / metadata
-                local exifData = {}
-                exifData.cameraMake = photo:getFormattedMetadata( "cameraMake" ) or ""
-                exifData.cameraModel = photo:getFormattedMetadata( "cameraModel" ) or ""
-                exifData.lens = photo:getFormattedMetadata( "lens" ) or ""
-                exifData.focalLength = photo:getFormattedMetadata( "focalLength" ) or ""
-                exifData.aperture = photo:getFormattedMetadata( "aperture" ) or ""
-                exifData.shutterSpeed = photo:getFormattedMetadata( "shutterSpeed" ) or ""
-                exifData.isoSpeedRating = photo:getFormattedMetadata( "isoSpeedRating" ) or ""
-                exifData.exposureBias = photo:getFormattedMetadata( "exposureBias" ) or ""
-                exifData.dateTimeOriginal = photo:getFormattedMetadata( "dateTimeOriginal" ) or ""
-                exifData.gps = photo:getFormattedMetadata( "gps" ) or ""
-                exifData.fileName = photo:getFormattedMetadata( "fileName" ) or ""
-                exifData.fileType = photo:getFormattedMetadata( "fileType" ) or ""
-                exifData.dimensions = photo:getFormattedMetadata( "dimensions" ) or ""
-                exifData.title = photo:getFormattedMetadata( "title" ) or ""
-                exifData.caption = photo:getFormattedMetadata( "caption" ) or ""
-                exifData.keywords = photo:getFormattedMetadata( "keywordTags" ) or ""
-                exifData.label = photo:getFormattedMetadata( "label" ) or ""
-                exifData.rating = photo:getFormattedMetadata( "rating" ) or ""
-
-                local exifJson = json.encode( exifData )
-
-                -- Percent-encode JSON so special chars survive HTTP headers
-                local exifEncoded = string.gsub( exifJson, "([^%w%-%.%_%~])", function( c )
-                    return string.format( "%%%02X", string.byte( c ) )
-                end )
+                local exifData = utils.collectExifData( photo )
+                local exifEncoded = utils.encodeExifHeader( exifData )
 
                 local headers = {
                     { field = 'Content-Type', value = 'image/jpeg' },

--- a/lrcembedindex.lrplugin/DescribePhoto.lua
+++ b/lrcembedindex.lrplugin/DescribePhoto.lua
@@ -6,6 +6,7 @@ local LrPrefs = import 'LrPrefs'
 local LrLogger = import 'LrLogger'
 
 local json = require 'dkjson'
+local utils = require 'LrCEmbedUtils'
 
 local logger = LrLogger( 'LrCEmbedIndex' )
 logger:enable( "logfile" )
@@ -31,33 +32,7 @@ local function describePhoto()
         local imagePath = photo:getRawMetadata( "path" ) or ""
         local fileName = photo:getFormattedMetadata( "fileName" ) or "photo"
 
-        -- Request JPEG thumbnail
-        local thumbnailPixels = nil
-        local thumbnailErr = nil
-        local done = false
-
-        local width = photo:getRawMetadata( "width" )
-        local height = photo:getRawMetadata( "height" )
-        if width and height then
-            width = math.min( width / 2, 1024 )
-            height = math.min( height / 2, 1024 )
-        else
-            width = 1024
-            height = 1024
-        end
-
-        photo:requestJpegThumbnail( width, height, function( pixels, errMsg )
-            thumbnailPixels = pixels
-            thumbnailErr = errMsg
-            done = true
-        end )
-
-        -- Wait for thumbnail (up to 30 seconds)
-        local waitCount = 0
-        while not done and waitCount < 300 do
-            LrTasks.sleep( 0.1 )
-            waitCount = waitCount + 1
-        end
+        local thumbnailPixels, thumbnailErr = utils.requestThumbnail( photo )
 
         if not thumbnailPixels or thumbnailErr then
             LrDialogs.message( "Error",
@@ -65,31 +40,8 @@ local function describePhoto()
             return
         end
 
-        -- Collect EXIF
-        local exifData = {}
-        exifData.cameraMake = photo:getFormattedMetadata( "cameraMake" ) or ""
-        exifData.cameraModel = photo:getFormattedMetadata( "cameraModel" ) or ""
-        exifData.lens = photo:getFormattedMetadata( "lens" ) or ""
-        exifData.focalLength = photo:getFormattedMetadata( "focalLength" ) or ""
-        exifData.aperture = photo:getFormattedMetadata( "aperture" ) or ""
-        exifData.shutterSpeed = photo:getFormattedMetadata( "shutterSpeed" ) or ""
-        exifData.isoSpeedRating = photo:getFormattedMetadata( "isoSpeedRating" ) or ""
-        exifData.exposureBias = photo:getFormattedMetadata( "exposureBias" ) or ""
-        exifData.dateTimeOriginal = photo:getFormattedMetadata( "dateTimeOriginal" ) or ""
-        exifData.gps = photo:getFormattedMetadata( "gps" ) or ""
-        exifData.fileName = photo:getFormattedMetadata( "fileName" ) or ""
-        exifData.fileType = photo:getFormattedMetadata( "fileType" ) or ""
-        exifData.dimensions = photo:getFormattedMetadata( "dimensions" ) or ""
-        exifData.title = photo:getFormattedMetadata( "title" ) or ""
-        exifData.caption = photo:getFormattedMetadata( "caption" ) or ""
-        exifData.keywords = photo:getFormattedMetadata( "keywordTags" ) or ""
-        exifData.label = photo:getFormattedMetadata( "label" ) or ""
-        exifData.rating = photo:getFormattedMetadata( "rating" ) or ""
-
-        local exifJson = json.encode( exifData )
-        local exifEncoded = string.gsub( exifJson, "([^%w%-%.%_%~])", function( c )
-            return string.format( "%%%02X", string.byte( c ) )
-        end )
+        local exifData = utils.collectExifData( photo )
+        local exifEncoded = utils.encodeExifHeader( exifData )
 
         local prefs = LrPrefs.prefsForPlugin()
         local serverUrl = prefs.serverUrl or "http://localhost:8600"

--- a/lrcembedindex.lrplugin/GenerateIndex.lua
+++ b/lrcembedindex.lrplugin/GenerateIndex.lua
@@ -7,6 +7,7 @@ local LrPrefs = import 'LrPrefs'
 local LrLogger = import 'LrLogger'
 
 local json = require 'dkjson'
+local utils = require 'LrCEmbedUtils'
 
 local logger = LrLogger( 'LrCEmbedIndex' )
 logger:enable( "logfile" )
@@ -55,64 +56,13 @@ local function generateIndex()
             progress:setPortionComplete( i - 1, #allPhotos )
             progress:setCaption( "Processing photo " .. i .. " of " .. #allPhotos )
 
-            -- Request JPEG thumbnail
-            local thumbnailPixels = nil
-            local thumbnailErr = nil
-            local done = false
-
-            local width = photo:getRawMetadata( "width" )
-            local height = photo:getRawMetadata( "height" )
-            if width and height then
-                width = math.min( width / 2, 1024 )
-                height = math.min( height / 2, 1024 )
-            else
-                width = 1024
-                height = 1024
-            end
-
-            local request = photo:requestJpegThumbnail( width, height, function( pixels, errMsg )
-                thumbnailPixels = pixels
-                thumbnailErr = errMsg
-                done = true
-            end )
-
-            -- Wait for thumbnail (up to 30 seconds)
-            local waitCount = 0
-            while not done and waitCount < 300 do
-                LrTasks.sleep( 0.1 )
-                waitCount = waitCount + 1
-            end
+            local thumbnailPixels, thumbnailErr = utils.requestThumbnail( photo )
 
             if thumbnailPixels and not thumbnailErr then
                 local imagePath = photo:getRawMetadata( "path" ) or ""
 
-                -- Collect EXIF / metadata
-                local exifData = {}
-                exifData.cameraMake = photo:getFormattedMetadata( "cameraMake" ) or ""
-                exifData.cameraModel = photo:getFormattedMetadata( "cameraModel" ) or ""
-                exifData.lens = photo:getFormattedMetadata( "lens" ) or ""
-                exifData.focalLength = photo:getFormattedMetadata( "focalLength" ) or ""
-                exifData.aperture = photo:getFormattedMetadata( "aperture" ) or ""
-                exifData.shutterSpeed = photo:getFormattedMetadata( "shutterSpeed" ) or ""
-                exifData.isoSpeedRating = photo:getFormattedMetadata( "isoSpeedRating" ) or ""
-                exifData.exposureBias = photo:getFormattedMetadata( "exposureBias" ) or ""
-                exifData.dateTimeOriginal = photo:getFormattedMetadata( "dateTimeOriginal" ) or ""
-                exifData.gps = photo:getFormattedMetadata( "gps" ) or ""
-                exifData.fileName = photo:getFormattedMetadata( "fileName" ) or ""
-                exifData.fileType = photo:getFormattedMetadata( "fileType" ) or ""
-                exifData.dimensions = photo:getFormattedMetadata( "dimensions" ) or ""
-                exifData.title = photo:getFormattedMetadata( "title" ) or ""
-                exifData.caption = photo:getFormattedMetadata( "caption" ) or ""
-                exifData.keywords = photo:getFormattedMetadata( "keywordTags" ) or ""
-                exifData.label = photo:getFormattedMetadata( "label" ) or ""
-                exifData.rating = photo:getFormattedMetadata( "rating" ) or ""
-
-                local exifJson = json.encode( exifData )
-
-                -- Percent-encode JSON so special chars (quotes, backslashes in GPS etc.) survive HTTP headers
-                local exifEncoded = string.gsub( exifJson, "([^%w%-%.%_%~])", function( c )
-                    return string.format( "%%%02X", string.byte( c ) )
-                end )
+                local exifData = utils.collectExifData( photo )
+                local exifEncoded = utils.encodeExifHeader( exifData )
 
                 local headers = {
                     { field = 'Content-Type', value = 'image/jpeg' },

--- a/lrcembedindex.lrplugin/LrCEmbedUtils.lua
+++ b/lrcembedindex.lrplugin/LrCEmbedUtils.lua
@@ -1,0 +1,79 @@
+local LrTasks = import 'LrTasks'
+
+local json = require 'dkjson'
+
+local LrCEmbedUtils = {}
+
+
+function LrCEmbedUtils.collectExifData( photo )
+    local exifData = {}
+    exifData.cameraMake = photo:getFormattedMetadata( "cameraMake" ) or ""
+    exifData.cameraModel = photo:getFormattedMetadata( "cameraModel" ) or ""
+    exifData.lens = photo:getFormattedMetadata( "lens" ) or ""
+    exifData.focalLength = photo:getFormattedMetadata( "focalLength" ) or ""
+    exifData.aperture = photo:getFormattedMetadata( "aperture" ) or ""
+    exifData.shutterSpeed = photo:getFormattedMetadata( "shutterSpeed" ) or ""
+    exifData.isoSpeedRating = photo:getFormattedMetadata( "isoSpeedRating" ) or ""
+    exifData.exposureBias = photo:getFormattedMetadata( "exposureBias" ) or ""
+    exifData.dateTimeOriginal = photo:getFormattedMetadata( "dateTimeOriginal" ) or ""
+    exifData.gps = photo:getFormattedMetadata( "gps" ) or ""
+    exifData.fileName = photo:getFormattedMetadata( "fileName" ) or ""
+    exifData.fileType = photo:getFormattedMetadata( "fileType" ) or ""
+    exifData.dimensions = photo:getFormattedMetadata( "dimensions" ) or ""
+    exifData.title = photo:getFormattedMetadata( "title" ) or ""
+    exifData.caption = photo:getFormattedMetadata( "caption" ) or ""
+    exifData.keywords = photo:getFormattedMetadata( "keywordTags" ) or ""
+    exifData.label = photo:getFormattedMetadata( "label" ) or ""
+    exifData.rating = photo:getFormattedMetadata( "rating" ) or ""
+    return exifData
+end
+
+
+function LrCEmbedUtils.requestThumbnail( photo, maxSize )
+    maxSize = maxSize or 1024
+
+    local thumbnailPixels = nil
+    local thumbnailErr = nil
+    local done = false
+
+    local width = photo:getRawMetadata( "width" )
+    local height = photo:getRawMetadata( "height" )
+    if width and height then
+        width = math.min( width / 2, maxSize )
+        height = math.min( height / 2, maxSize )
+    else
+        width = maxSize
+        height = maxSize
+    end
+
+    photo:requestJpegThumbnail( width, height, function( pixels, errMsg )
+        thumbnailPixels = pixels
+        thumbnailErr = errMsg
+        done = true
+    end )
+
+    -- Wait for thumbnail (up to 30 seconds)
+    local waitCount = 0
+    while not done and waitCount < 300 do
+        LrTasks.sleep( 0.1 )
+        waitCount = waitCount + 1
+    end
+
+    return thumbnailPixels, thumbnailErr
+end
+
+
+function LrCEmbedUtils.percentEncode( str )
+    return string.gsub( str, "([^%w%-%.%_%~])", function( c )
+        return string.format( "%%%02X", string.byte( c ) )
+    end )
+end
+
+
+function LrCEmbedUtils.encodeExifHeader( exifData )
+    local exifJson = json.encode( exifData )
+    return LrCEmbedUtils.percentEncode( exifJson )
+end
+
+
+return LrCEmbedUtils


### PR DESCRIPTION
## Summary
- Create `LrCEmbedUtils.lua` with shared functions: `collectExifData()`, `requestThumbnail()`, `percentEncode()`, `encodeExifHeader()`
- Update `GenerateIndex.lua`, `BatchDescribe.lua`, and `DescribePhoto.lua` to use the shared module
- Net reduction: ~160 lines of duplicated code replaced by ~80-line shared module

## Test plan
- [x] Generate Index works as before (EXIF, thumbnails, encoding all pass through correctly)
- [ ] Batch Describe works as before
- [x] Describe Photo works as before
- [ ] All three operations produce identical HTTP requests to the server as before the refactor

Fixes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)