### PR TITLE
Fix server binding to 0.0.0.0 and API key leak

### DIFF
--- a/server/config.py
+++ b/server/config.py
@@ -85,5 +85,6 @@ def load_config():
 
 def save_last_config_pointer():
     home_config = os.path.join(str(Path.home()), ".lrcembedindex_last_config.json")
+    safe = {k: v for k, v in config.items() if "api_key" not in k}
     with open(home_config, "w") as f:
-        json.dump(config, f, indent=2)
+        json.dump(safe, f, indent=2)

--- a/server/server.py
+++ b/server/server.py
@@ -32,4 +32,4 @@ def startup():
 if __name__ == "__main__":
     startup()
     app = create_app()
-    app.run(host="0.0.0.0", port=8600, debug=False)
+    app.run(host="127.0.0.1", port=8600, debug=False)


### PR DESCRIPTION
## Summary
- Bind server to `127.0.0.1` instead of `0.0.0.0` to prevent LAN exposure of unauthenticated API
- Filter API keys from `save_last_config_pointer()` to prevent credentials being written to `~/.lrcembedindex_last_config.json`

## Test plan
- [x] Server only accepts connections from localhost after restart
- [x] `~/.lrcembedindex_last_config.json` does not contain any `*api_key*` fields after `/settings` is called
- [x] Server still loads config correctly on restart (index_folder, model settings persist)

Fixes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)