### PR TITLE
Add Docker deployment, auto patrol, and API key encryption

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+.git
+.github
+*.md
+LICENSE
+lrcembedindex.lrplugin
+docker/data
+server/__pycache__
+server/*.pyc

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,38 @@
 
 All notable changes to LrCEmbedIndex will be documented in this file.
 
+## [1.2.0] - 2026-04-07
+
+### Added
+- **Standalone server mode** — server runs independently without Lightroom plugin
+- **Settings Web UI** (`/settings-ui`) — configure all models, API keys, and patrol settings from the browser
+- **Auto patrol** — background worker scans configured folders and indexes new/changed photos automatically
+- **Encrypted API key storage** — API keys encrypted at rest using Fernet symmetric encryption
+- **Docker deployment** — Dockerfile, docker-compose.yml, and rebuild.sh for containerized deployment
+- **Content hash deduplication** — SHA-256 content hash used as ChromaDB document ID to prevent duplicates
+- **X-Content-Hash header** — Lightroom plugin computes and sends content hash for remote Docker scenarios
+- **Photo detail hash display** — content hash shown on photo detail web page
+- **PHOTO_FOLDER volume mount** — configurable photo folder for Docker auto patrol
+- **`--host` / `--port` CLI args** — configurable bind address for Docker (0.0.0.0) vs local (127.0.0.1)
+- **Patrol status auto-refresh** — settings UI refreshes patrol status every 60 seconds
+- **"Load from Server" button** — Lightroom plugin can pull settings from the server
+
+### Changed
+- Index folder setting removed from Lightroom plugin UI (now configured via web Settings UI only)
+- API keys encrypted before writing to config file on disk
+- Patrol worker gracefully skips unsupported RAW formats (e.g. Nikon Z9/Z8 compressed NEF)
+
+### Fixed
+- Division by zero in EXIF extraction when exposure time is 0
+- Patrol status stuck on "idle" after pressing Start
+- Race condition in Fernet key initialization with double-checked locking
+
+## [1.1.0] - 2026-03-30
+
+### Added
+- **MCP server** — Model Context Protocol integration for Claude and other MCP clients
+- MCP tools: `search_photos`, `get_photo_info`, `get_stats`
+
 ## [1.0.0] - 2026-03-23
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ pip install -r requirements.txt
 ## Making Changes
 
 - Keep changes focused — one feature or fix per pull request
-- Follow existing code style (no linter is enforced yet)
+- Follow existing code style — Python code is linted with [ruff](https://docs.astral.sh/ruff/) via CI on every push and PR
 - Test your changes with the Lightroom plugin and Python server before submitting
 
 ## Submitting a Pull Request

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -38,7 +38,9 @@ Review each provider's data handling policies:
 
 ## API key handling
 
-API keys are stored in Lightroom plugin preferences and kept in-memory on the server. They are **never written to config files on disk** and are redacted from all API responses.
+API keys are encrypted at rest using Fernet symmetric encryption and stored in `lrcembedindex_config.json` with an `ENC:` prefix. The encryption key is stored in `~/.lrcembedindex_key` with restrictive file permissions (0600). API keys are redacted from all API responses except the `/settings/sync` endpoint (see Network deployment below).
+
+When using the Lightroom plugin, API keys are also stored in Lightroom plugin preferences.
 
 ## Data deletion
 
@@ -52,7 +54,24 @@ To delete all indexed data, remove the index folder.
 
 ## Local server
 
-The server binds to `127.0.0.1` (localhost only) and is not accessible from the network. No authentication is required because only local processes can connect. Cross-origin requests are restricted to localhost origins.
+By default, the server binds to `127.0.0.1` (localhost only) and is not accessible from the network. No authentication is required because only local processes can connect. Cross-origin requests are restricted to localhost origins.
+
+## Network deployment (Docker)
+
+When running in Docker with `--host 0.0.0.0`, the server is accessible to all machines on the network. In this configuration:
+
+- The `/settings/sync` endpoint returns **unmasked API keys** so the Lightroom plugin can load settings from the server. Anyone on the network can access this endpoint.
+- All indexed data (metadata, thumbnails, descriptions) is accessible via the web UI.
+- There is no authentication mechanism — access control relies on network-level restrictions.
+
+**To restrict access**, bind to a specific interface in `docker-compose.yml`:
+
+```yaml
+ports:
+  - "192.168.1.100:8600:8600"   # only accessible via this IP
+```
+
+Or use firewall rules to limit which machines can reach port 8600.
 
 ## Contact
 

--- a/README.md
+++ b/README.md
@@ -38,27 +38,41 @@ LrCEmbedIndex/
 │   ├── SearchPhoto.lua          # Menu: semantic search with collection results
 │   ├── DescribePhoto.lua        # Menu: describe a single selected photo
 │   ├── ShowStats.lua            # Menu: show ChromaDB & metadata statistics
+│   ├── SearchInBrowser.lua      # Menu: open search in browser
 │   ├── PluginInfoProvider.lua   # Settings UI
-│   └── dkjson.lua               # JSON library
+│   ├── LrCEmbedUtils.lua       # Utility functions (thumbnails, EXIF, content hash)
+│   └── dkjson.lua               # JSON library (MIT)
 ├── server/
 │   ├── server.py                # Flask app entry point
 │   ├── routes.py                # API route handlers
-│   ├── config.py                # Configuration management
+│   ├── config.py                # Configuration management (encrypted API keys)
+│   ├── keystore.py              # Fernet encryption for API key storage
 │   ├── vision.py                # Vision model integration (Ollama/OpenAI/Claude)
 │   ├── embedding.py             # Embedding model integration (Ollama/OpenAI/Voyage AI)
 │   ├── vectorstore.py           # ChromaDB vector store with relevance filtering
 │   ├── metadata.py              # Sharded JSON metadata storage
 │   ├── helpers.py               # EXIF-to-text conversion, utilities
+│   ├── photo_utils.py           # Shared photo discovery, thumbnails, EXIF extraction
+│   ├── patrol.py                # Background auto-indexing worker
+│   ├── mcp_server.py            # MCP server for Claude and MCP clients
 │   ├── ollama_lock.py           # Threading lock for Ollama call serialization
+│   ├── scan_and_index.py        # CLI batch indexing script
 │   ├── requirements.txt         # Python dependencies
-│   └── requirements-lock.txt    # Pinned dependency versions
-├── .github/workflows/lint.yml  # CI: Python linting
+│   ├── requirements-lock.txt    # Pinned dependency versions
+│   └── templates/               # Web UI templates (search, photo, settings, stats, etc.)
+├── docker/
+│   ├── Dockerfile               # Python 3.11-slim with libraw for RAW support
+│   ├── docker-compose.yml       # Service definition with volume mounts
+│   ├── rebuild.sh               # Stop, rebuild, and deploy container
+│   └── README.md                # Docker deployment documentation
+├── .github/workflows/lint.yml   # CI: Python linting with ruff
 ├── README.md
 ├── LICENSE
 ├── CHANGELOG.md
 ├── CONTRIBUTING.md
 ├── CODE_OF_CONDUCT.md
-└── SECURITY.md
+├── SECURITY.md
+└── PRIVACY.md
 ```
 
 ## Prerequisites
@@ -99,23 +113,20 @@ The server runs on port 8600 by default.
 
    **General Settings:**
    - **Python Server URL** (default: `http://localhost:8600`)
-   - **Index & Metadata Folder** — where metadata and ChromaDB data are stored
    - **Search Max Results** — max candidates from vector DB per search (default: 10)
    - **Relevance Threshold** — slider (0–100) controlling how strict the relevance filter is
 
-   **Vision Model:**
-   - Choose between **Ollama**, **OpenAI API**, or **Claude API**
-   - Ollama: endpoint URL + model name (default: `qwen3.5`)
-   - OpenAI: API key + model name (default: `gpt-4o`)
-   - Claude: API key + model name (default: `claude-sonnet-4-6`)
-
-   **Embedding Model:**
-   - Choose between **Ollama**, **OpenAI API**, or **Voyage AI**
-   - Ollama: endpoint URL + model name (default: `nomic-embed-text`)
-   - OpenAI: API key + model name (default: `text-embedding-3-small`)
-   - Voyage AI: API key + model name (default: `voyage-3.5`)
+   **Vision & Embedding Models** — choose backends and configure API keys. You can also use "Load from Server" to pull settings from the server's web Settings UI.
 
 5. Click **Save & Apply Settings**
+
+### Settings Web UI
+
+Open `http://localhost:8600/settings-ui` in a browser to configure all settings including:
+- Index folder path
+- Vision and embedding model backends and API keys
+- Auto patrol folders and intervals
+- API keys are encrypted at rest using Fernet symmetric encryption
 
 ## Usage
 
@@ -167,6 +178,44 @@ The server runs on port 8600 by default.
 | `/describe` | POST | Describe a single photo (vision only, uses cache). Body: JPEG data. Headers: `X-Image-Path`, `X-Exif-Data` |
 | `/stats` | GET | Get metadata, ChromaDB, and config statistics |
 | `/settings` | POST | Update config. Body: JSON with any config keys |
+| `/settings-ui` | GET | Settings web UI |
+| `/settings/sync` | GET | Full config including API keys (for plugin sync) |
+| `/patrol/status` | GET | Auto patrol worker status |
+| `/patrol/start` | POST | Start patrol worker |
+| `/patrol/stop` | POST | Stop patrol worker |
+| `/patrol/pause` | POST | Pause patrol worker |
+
+## Standalone Mode (Auto Patrol)
+
+The server can run independently without the Lightroom plugin, automatically scanning and indexing photos from configured folders:
+
+1. Configure patrol folders via the Settings Web UI (`/settings-ui`)
+2. Set the scan interval (default: 60 minutes)
+3. Click **Start** to begin auto-indexing
+
+The patrol worker runs in a background thread, scanning folders for new or changed photos. It uses the same vision and embedding pipeline as the Lightroom plugin. When Lightroom sends an indexing request, the patrol worker automatically pauses and resumes after the request completes.
+
+## Docker Deployment
+
+Run the server in a Docker container for remote/NAS deployment:
+
+```bash
+INDEX_FOLDER=/path/to/index PHOTO_FOLDER=/path/to/photos ./docker/rebuild.sh
+```
+
+The server is accessible at `http://<hostname>:8600`. Set the **Index Folder** to `/data` and patrol folders to `/photos` in the Settings UI (these are container-side mount points).
+
+See [docker/README.md](docker/README.md) for full configuration, remote deployment via Docker contexts, and security considerations.
+
+## MCP Server
+
+The project includes an MCP (Model Context Protocol) server for integration with Claude and other MCP clients:
+
+```bash
+python server/mcp_server.py
+```
+
+Available MCP tools: `search_photos`, `get_photo_info`, `get_stats`.
 
 ## Data Storage
 
@@ -246,7 +295,7 @@ All model names are configurable in the plugin settings UI. Here are reference l
   - [Anthropic Usage Policy](https://www.anthropic.com/policies/usage-policy)
   - [Voyage AI Terms of Service](https://www.voyageai.com/terms-of-service)
 - **Local storage only:** All metadata, embeddings, and configuration are stored locally on your machine. No telemetry or analytics are collected.
-- **API keys** are stored in Lightroom plugin preferences and kept in-memory on the server. They are never written to config files on disk.
+- **API keys** are encrypted at rest using Fernet symmetric encryption. See [PRIVACY.md](PRIVACY.md) for details.
 
 Users are responsible for complying with the terms of service of their chosen API providers.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -24,16 +24,28 @@ If you discover a security vulnerability in LrCEmbedIndex, please report it resp
 
 ### API Keys
 
-- API keys (OpenAI, Claude, Voyage AI) are stored only in Lightroom plugin preferences and in-memory on the Python server at runtime.
-- API keys are **never** written to config files on disk (filtered by `config.py`).
-- API keys are **never** logged or exposed via the `/stats` endpoint.
+- API keys (OpenAI, Claude, Voyage AI) are encrypted at rest using Fernet symmetric encryption and stored in `lrcembedindex_config.json` with an `ENC:` prefix.
+- The encryption key is stored in `~/.lrcembedindex_key` with restrictive file permissions (0600).
+- API keys are redacted from `/stats` and `GET /settings` responses (masked to last 4 characters).
+- The `/settings/sync` endpoint returns **unmasked** API keys for Lightroom plugin synchronization. See Docker security below.
+- API keys are **never** logged.
 
 ### Data Transmission
 
 - When using **Ollama** (default), all processing is local — no data leaves your machine.
-- When using **OpenAI**, **Claude**, or **Voyage AI** backends, photo images and/or description text are sent to third-party API servers. See the [Privacy Notice](#privacy-notice) in README.md.
+- When using **OpenAI**, **Claude**, or **Voyage AI** backends, photo images and/or description text are sent to third-party API servers. See [PRIVACY.md](PRIVACY.md).
+- GPS data is stripped from cloud API requests by default (`strip_gps_for_cloud`).
 
 ### Local Server
 
 - The Python server binds to `localhost:8600` by default and is not exposed to the network.
 - No authentication is required for the local server API (it is intended for local use only).
+- Cross-origin requests are restricted to localhost origins.
+
+### Docker / Network Deployment
+
+When running the server in Docker with `--host 0.0.0.0`, additional security considerations apply:
+
+- **No authentication**: The server has no authentication mechanism. Anyone on the network can access all endpoints, including `/settings/sync` which returns unmasked API keys.
+- **Restrict network access**: Bind to a specific interface or use firewall rules to limit access. See [docker/README.md](docker/README.md) for configuration examples.
+- **Encryption key persistence**: The Docker setup uses a named volume (`lrcembedindex-key`) to persist the Fernet encryption key across container rebuilds. Do not share this volume with untrusted containers.

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,24 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+# Install system dependencies for rawpy (libraw) and Pillow
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    libraw-dev \
+    libjpeg62-turbo-dev \
+    zlib1g-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Python dependencies
+COPY server/requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy server code
+COPY server/ .
+
+# Expose the server port
+EXPOSE 8600
+
+# Bind to 0.0.0.0 so the container is reachable from the host/network
+CMD ["python", "server.py", "--host", "0.0.0.0"]

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,138 @@
+# Docker Deployment
+
+Run the LrCEmbedIndex server in a Docker container, accessible from other machines on the network.
+
+## Files
+
+| File | Description |
+|------|-------------|
+| `Dockerfile` | Builds the server image (Python 3.11-slim with libraw for RAW photo support) |
+| `docker-compose.yml` | Defines the service, ports, and volume mounts |
+| `rebuild.sh` | Stops, removes, rebuilds, and deploys the container from scratch |
+
+## Quick Start
+
+```bash
+# From the project root
+INDEX_FOLDER=/path/to/your/photos ./docker/rebuild.sh
+```
+
+The server will be available at `http://<hostname>:8600`.
+
+Open `http://<hostname>:8600/settings-ui` and set the **Index Folder** to `/data` (this is the container-side mount point for your host folder).
+
+## Configuration
+
+### Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `INDEX_FOLDER` | `./docker/data` | Host path for index/metadata storage, mounted to `/data` in the container |
+
+### Volumes
+
+The `docker-compose.yml` defines two volume mounts:
+
+1. **Index data** (`${INDEX_FOLDER}:/data`) — Your photos, metadata JSON shards, ChromaDB vectors, and thumbnails. This is a bind mount to a host directory so data persists across container rebuilds.
+
+2. **Encryption key** (`lrcembedindex-key:/root`) — A named Docker volume that persists `~/.lrcembedindex_key` (the Fernet encryption key for API keys). This ensures encrypted API keys remain decryptable after container rebuilds.
+
+### Ports
+
+The container exposes port **8600**. To change the host port:
+
+```bash
+# Edit docker-compose.yml ports section, e.g.:
+ports:
+  - "9000:8600"   # host:container
+```
+
+### Important: Index Folder Path
+
+The index folder path in the Settings UI must be `/data` (the container-side path), not the host path. The volume mount translates between the two:
+
+```
+Host: /home/user/photos  <-->  Container: /data
+```
+
+## Usage
+
+### Local Deployment
+
+```bash
+# Start with default data directory (./docker/data)
+./docker/rebuild.sh
+
+# Start with a specific host directory
+INDEX_FOLDER=/mnt/nas/photos ./docker/rebuild.sh
+```
+
+### Remote Deployment via Docker Context
+
+Deploy to a remote machine without SSH-ing into it:
+
+```bash
+# Set up a remote Docker context (one-time)
+docker context create my-server --docker "host=ssh://user@192.168.1.100"
+
+# Deploy to the remote machine
+docker context use my-server
+INDEX_FOLDER=/remote/path/to/photos ./docker/rebuild.sh
+
+# Switch back to local
+docker context use default
+```
+
+### Container Management
+
+```bash
+cd docker
+
+# View logs
+docker compose logs -f
+
+# Stop the container
+docker compose down
+
+# Restart without rebuilding
+docker compose restart
+
+# Check status
+docker compose ps
+```
+
+## Web UI Endpoints
+
+Once running, these are accessible from any machine on the network:
+
+| URL | Description |
+|-----|-------------|
+| `http://<host>:8600/` | Search photos |
+| `http://<host>:8600/settings-ui` | Configure models, patrol folders, API keys |
+| `http://<host>:8600/stats-ui` | Index statistics |
+
+## Patrol with Docker
+
+When configuring patrol folders in the Settings UI, use **container-side paths**. For example, if you mount additional directories:
+
+```yaml
+# docker-compose.yml
+volumes:
+  - /host/photos:/data
+  - /host/more-photos:/photos2
+```
+
+Then in the Settings UI, add `/data` and `/photos2` as patrol folders.
+
+## Connecting Lightroom Plugin
+
+Point the Lightroom plugin's **Server URL** to `http://<docker-host-ip>:8600`. The plugin communicates over HTTP, so it works across the network without any special configuration.
+
+## Security Note
+
+When running in Docker with `0.0.0.0` binding, the server is accessible to all machines on the network. The `/settings/sync` endpoint returns full API keys. If this is a concern, restrict access via firewall rules or change the port mapping to bind to a specific interface:
+
+```yaml
+ports:
+  - "192.168.1.100:8600:8600"   # only accessible via this IP
+```

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -11,6 +11,8 @@ services:
       # Mount host index/metadata folder into the container.
       # Change the left side to your actual host path.
       - ${INDEX_FOLDER:-./data}:/data
+      # Mount host photo folder(s) for auto patrol
+      - ${PHOTO_FOLDER:-./photos}:/photos
       # Persist the encryption key across container rebuilds
       - lrcembedindex-key:/root
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,18 @@
+services:
+  lrcembedindex:
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile
+    container_name: lrcembedindex
+    restart: unless-stopped
+    ports:
+      - "8600:8600"
+    volumes:
+      # Mount host index/metadata folder into the container.
+      # Change the left side to your actual host path.
+      - ${INDEX_FOLDER:-./data}:/data
+      # Persist the encryption key across container rebuilds
+      - lrcembedindex-key:/root
+
+volumes:
+  lrcembedindex-key:

--- a/docker/rebuild.sh
+++ b/docker/rebuild.sh
@@ -8,6 +8,7 @@
 #
 # Environment variables:
 #   INDEX_FOLDER  Host path for index/metadata storage (default: ./docker/data)
+#   PHOTO_FOLDER  Host path for photo folder to patrol (default: ./docker/photos)
 #
 set -euo pipefail
 

--- a/docker/rebuild.sh
+++ b/docker/rebuild.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+#
+# Rebuild and deploy the LrCEmbedIndex Docker container from scratch.
+#
+# Usage:
+#   Local:   ./docker/rebuild.sh
+#   Remote:  docker context use <remote-context> && ./docker/rebuild.sh
+#
+# Environment variables:
+#   INDEX_FOLDER  Host path for index/metadata storage (default: ./docker/data)
+#
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+echo "==> Stopping and removing existing container..."
+docker compose -f "$SCRIPT_DIR/docker-compose.yml" down --remove-orphans 2>/dev/null || true
+
+echo "==> Removing old image..."
+docker rmi lrcembedindex 2>/dev/null || true
+# Also remove the compose-built image (named after the directory)
+docker rmi docker-lrcembedindex 2>/dev/null || true
+
+echo "==> Building fresh image..."
+docker compose -f "$SCRIPT_DIR/docker-compose.yml" build --no-cache
+
+echo "==> Starting container..."
+docker compose -f "$SCRIPT_DIR/docker-compose.yml" up -d
+
+echo "==> Done. Container status:"
+docker compose -f "$SCRIPT_DIR/docker-compose.yml" ps
+
+echo ""
+echo "Server is running at http://$(hostname):8600"
+echo "Settings UI:  http://$(hostname):8600/settings-ui"
+echo ""
+echo "Set the Index Folder to /data in the Settings UI."
+echo "This maps to \${INDEX_FOLDER:-./docker/data} on the host."

--- a/lrcembedindex.lrplugin/GenerateIndex.lua
+++ b/lrcembedindex.lrplugin/GenerateIndex.lua
@@ -64,12 +64,17 @@ local function generateIndex()
                 local exifData = utils.collectExifData( photo )
                 local exifEncoded = utils.encodeExifHeader( exifData )
 
+                local contentHash = utils.computeContentHash( imagePath )
+
                 local headers = {
                     { field = 'Content-Type', value = 'image/jpeg' },
                     { field = 'Content-Length', value = string.len( thumbnailPixels ) },
                     { field = 'X-Image-Path', value = imagePath },
                     { field = 'X-Exif-Data', value = exifEncoded },
                 }
+                if contentHash then
+                    headers[#headers + 1] = { field = 'X-Content-Hash', value = contentHash }
+                end
 
                 local response, hdrs = LrHttp.post(
                     serverUrl .. "/index",

--- a/lrcembedindex.lrplugin/LrCEmbedUtils.lua
+++ b/lrcembedindex.lrplugin/LrCEmbedUtils.lua
@@ -63,6 +63,24 @@ function LrCEmbedUtils.requestThumbnail( photo, maxSize )
 end
 
 
+function LrCEmbedUtils.computeContentHash( filePath )
+    -- Compute SHA-256 of file content using shasum (macOS/Linux)
+    -- Returns "sha256:<hex>" or nil on failure
+    local quoted = filePath:gsub( "'", "'\\''" )
+    local handle = io.popen( "shasum -a 256 '" .. quoted .. "' 2>/dev/null" )
+    if not handle then return nil end
+    local result = handle:read( "*a" )
+    handle:close()
+    if result then
+        local hex = result:match( "^(%x+)" )
+        if hex and #hex == 64 then
+            return "sha256:" .. hex
+        end
+    end
+    return nil
+end
+
+
 function LrCEmbedUtils.percentEncode( str )
     return string.gsub( str, "([^%w%-%.%_%~])", function( c )
         return string.format( "%%%02X", string.byte( c ) )

--- a/lrcembedindex.lrplugin/PluginInfoProvider.lua
+++ b/lrcembedindex.lrplugin/PluginInfoProvider.lua
@@ -13,8 +13,6 @@ local function sectionsForTopOfDialog( f, propertyTable )
 
     -- Defaults
     if not prefs.serverUrl then prefs.serverUrl = "http://localhost:8600" end
-    if not prefs.indexFolder then prefs.indexFolder = "" end
-
     -- Vision settings
     if not prefs.visionMode then prefs.visionMode = "ollama" end
     if not prefs.ollamaVisionEndpoint then prefs.ollamaVisionEndpoint = "http://localhost:11434" end
@@ -39,7 +37,6 @@ local function sectionsForTopOfDialog( f, propertyTable )
 
     -- Bind to property table
     propertyTable.serverUrl = prefs.serverUrl
-    propertyTable.indexFolder = prefs.indexFolder
     propertyTable.searchMaxResults = prefs.searchMaxResults
     propertyTable.searchRelevance = prefs.searchRelevance
 
@@ -81,7 +78,7 @@ local function sectionsForTopOfDialog( f, propertyTable )
     return {
         {
             title = "LrC Embed Index — General",
-            synopsis = "Server and index folder settings",
+            synopsis = "Server and search settings",
 
             f:row {
                 f:static_text {
@@ -92,32 +89,6 @@ local function sectionsForTopOfDialog( f, propertyTable )
                 f:edit_field {
                     value = LrView.bind { key = 'serverUrl', object = propertyTable },
                     width_in_chars = 40,
-                },
-            },
-
-            f:row {
-                f:static_text {
-                    title = "Index & Metadata Folder:",
-                    alignment = 'right',
-                    width = LrView.share 'label_width',
-                },
-                f:edit_field {
-                    value = LrView.bind { key = 'indexFolder', object = propertyTable },
-                    width_in_chars = 30,
-                },
-                f:push_button {
-                    title = "Browse...",
-                    action = function( button )
-                        local path = LrDialogs.runOpenPanel {
-                            title = "Select Index Folder",
-                            canChooseFiles = false,
-                            canChooseDirectories = true,
-                            allowsMultipleSelection = false,
-                        }
-                        if path then
-                            propertyTable.indexFolder = path[1]
-                        end
-                    end,
                 },
             },
 
@@ -430,7 +401,6 @@ local function sectionsForTopOfDialog( f, propertyTable )
                         local c = data.config
 
                         -- Update property table with server values
-                        if c.index_folder then propertyTable.indexFolder = c.index_folder end
                         if c.search_max_results then propertyTable.searchMaxResults = c.search_max_results end
                         if c.search_relevance then propertyTable.searchRelevance = c.search_relevance end
 
@@ -467,7 +437,6 @@ local function sectionsForTopOfDialog( f, propertyTable )
                     action = function( button )
                         -- Persist to prefs
                         prefs.serverUrl = propertyTable.serverUrl
-                        prefs.indexFolder = propertyTable.indexFolder
                         prefs.searchMaxResults = propertyTable.searchMaxResults
                         prefs.searchRelevance = propertyTable.searchRelevance
 
@@ -489,8 +458,6 @@ local function sectionsForTopOfDialog( f, propertyTable )
 
                         -- Send all settings to the Python server
                         local payload = json.encode({
-                            index_folder = propertyTable.indexFolder,
-
                             vision_mode = propertyTable.visionMode,
                             ollama_vision_endpoint = propertyTable.ollamaVisionEndpoint,
                             ollama_vision_model = propertyTable.ollamaVisionModel,

--- a/server/requirements-lock.txt
+++ b/server/requirements-lock.txt
@@ -1,8 +1,10 @@
 # Pinned dependency versions for reproducible installs.
 # Generated from requirements.txt minimum versions.
-# Update by running: pip freeze | grep -iE "flask|requests|chromadb|pillow|rawpy" > requirements-lock.txt
+# Update by running: pip freeze | grep -iE "flask|requests|chromadb|pillow|rawpy|mcp|cryptography" > requirements-lock.txt
 Flask==3.0.0
 requests==2.31.0
 chromadb==0.5.0
 Pillow==12.2.0
 rawpy==0.26.1
+mcp==1.0.0
+cryptography==41.0.0

--- a/server/routes.py
+++ b/server/routes.py
@@ -150,6 +150,14 @@ def get_metadata():
             if "embedding" in e_data:
                 e_data["embedding"] = f"[{len(e_data['embedding'])} dimensions]"
 
+    # Compute content hash for display
+    try:
+        content_hash = compute_content_hash(image_path)
+    except (FileNotFoundError, PermissionError):
+        content_hash = None
+
+    safe_meta["content_hash"] = content_hash
+
     return jsonify({"status": "ok", "metadata": safe_meta,
                     "has_thumbnail": has_thumbnail(image_path)})
 
@@ -366,15 +374,17 @@ def index_photo():
                 save_thumbnail(image_path, small_thumb)
 
             # Always upsert to ChromaDB — we don't know which model pair
-            # produced the current entry, so keep it in sync
+            # produced the current entry, so keep it in sync.
+            # Use client-provided hash when original file is not accessible
+            # (e.g. remote Docker server receiving from Lightroom plugin).
             try:
                 doc_id = compute_content_hash(image_path)
-            except FileNotFoundError:
-                return jsonify({"status": "error",
-                                "message": f"Original file not accessible: {image_path}"}), 400
-            except PermissionError:
-                return jsonify({"status": "error",
-                                "message": f"Permission denied reading: {image_path}"}), 403
+            except (FileNotFoundError, PermissionError):
+                doc_id = request.headers.get("X-Content-Hash", "")
+                if not doc_id:
+                    return jsonify({"status": "error",
+                                    "message": "Original file not accessible and "
+                                    "no X-Content-Hash header provided"}), 400
             upsert_photo(doc_id, embedding, description, image_path)
 
             elapsed = time.time() - t_start

--- a/server/server.py
+++ b/server/server.py
@@ -1,3 +1,4 @@
+import argparse
 import logging
 
 from flask import Flask
@@ -43,6 +44,13 @@ def startup():
 
 
 if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="LrCEmbedIndex server")
+    parser.add_argument("--host", default="127.0.0.1",
+                        help="Bind address (default: 127.0.0.1, use 0.0.0.0 for Docker)")
+    parser.add_argument("--port", type=int, default=8600,
+                        help="Port number (default: 8600)")
+    args = parser.parse_args()
+
     startup()
     app = create_app()
-    app.run(host="127.0.0.1", port=8600, debug=False)
+    app.run(host=args.host, port=args.port, debug=False)

--- a/server/templates/licenses.html
+++ b/server/templates/licenses.html
@@ -79,6 +79,15 @@ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.</div>
     <div class="meta">MIT &mdash; <a href="https://github.com/letmaik/rawpy/blob/master/LICENSE" target="_blank">License</a></div>
   </div>
 
+  <div class="license-block">
+    <div class="name">mcp (Model Context Protocol SDK)</div>
+    <div class="meta">MIT &mdash; <a href="https://github.com/modelcontextprotocol/python-sdk/blob/main/LICENSE" target="_blank">License</a></div>
+  </div>
+  <div class="license-block">
+    <div class="name">cryptography</div>
+    <div class="meta">Apache-2.0 OR BSD-3-Clause &mdash; <a href="https://github.com/pyca/cryptography/blob/main/LICENSE" target="_blank">License</a></div>
+  </div>
+
   <h2>Lua Dependencies</h2>
   <div class="license-block">
     <div class="name">dkjson</div>

--- a/server/templates/photo.html
+++ b/server/templates/photo.html
@@ -192,7 +192,7 @@ async function loadPhoto() {
     html += `<button class="btn-danger" onclick="deleteFromIndex()">Delete from index</button>`;
     html += `<a href="/thumbnail?path=${encodeURIComponent(imagePath)}" target="_blank">View thumbnail</a>`;
     if (meta.content_hash) {
-      html += `<span class="embed-tag">Hash: ${escapeHtml(meta.content_hash.substring(0, 20))}...</span>`;
+      html += `<span class="embed-tag">Hash: ${escapeHtml(meta.content_hash)}</span>`;
     }
     html += '</div></div></div>';
 

--- a/server/templates/privacy.html
+++ b/server/templates/privacy.html
@@ -81,7 +81,7 @@
   </ul>
 
   <h2>API key handling</h2>
-  <p>API keys are stored in Lightroom plugin preferences and kept in-memory on the server. They are <strong>never written to config files on disk</strong> and are redacted from all API responses.</p>
+  <p>API keys are encrypted at rest using Fernet symmetric encryption and stored in <code>lrcembedindex_config.json</code> with an <code>ENC:</code> prefix. The encryption key is stored in <code>~/.lrcembedindex_key</code> with restrictive file permissions (0600). API keys are redacted from all API responses except the <code>/settings/sync</code> endpoint (see Network deployment below).</p>
 
   <h2>Data deletion</h2>
   <p>You can delete all indexed data for a specific photo via:</p>
@@ -93,7 +93,16 @@
   <p>To delete all indexed data, remove the index folder.</p>
 
   <h2>Local server</h2>
-  <p>The server binds to <code>127.0.0.1</code> (localhost only) and is not accessible from the network. No authentication is required because only local processes can connect. Cross-origin requests are restricted to localhost origins.</p>
+  <p>By default, the server binds to <code>127.0.0.1</code> (localhost only) and is not accessible from the network. No authentication is required because only local processes can connect. Cross-origin requests are restricted to localhost origins.</p>
+
+  <h2>Network deployment (Docker)</h2>
+  <p>When running in Docker with <code>--host 0.0.0.0</code>, the server is accessible to all machines on the network. In this configuration:</p>
+  <ul>
+    <li>The <code>/settings/sync</code> endpoint returns <strong>unmasked API keys</strong> so the Lightroom plugin can load settings from the server.</li>
+    <li>All indexed data (metadata, thumbnails, descriptions) is accessible via the web UI.</li>
+    <li>There is no authentication mechanism &mdash; access control relies on network-level restrictions.</li>
+  </ul>
+  <p>To restrict access, bind to a specific interface in <code>docker-compose.yml</code> or use firewall rules.</p>
 
   <h2>Contact</h2>
   <p>For privacy questions, open an issue at <a href="https://github.com/yutakas/LrCEmbedIndex/issues" target="_blank">github.com/yutakas/LrCEmbedIndex/issues</a>.</p>


### PR DESCRIPTION
## Changes

### Major Features
- **Docker deployment**: Dockerfile, docker-compose.yml, and rebuild.sh for containerized deployment
- **Auto patrol**: Background worker scans configured folders and automatically indexes new/changed photos
- **Encrypted API keys**: API keys encrypted at rest using Fernet symmetric encryption (stored in `~/.lrcembedindex_key`)
- **Standalone server mode**: Server runs independently without Lightroom plugin
- **Settings Web UI** (`/settings-ui`): Configure models, API keys, and patrol settings from browser
- **Content hash deduplication**: SHA-256 content hash used as ChromaDB document ID to prevent duplicates
- **MCP server**: Model Context Protocol integration for Claude and other MCP clients

### Plugin Changes
- Removed "Index & Metadata Folder" setting from Lightroom plugin UI (now configured via web Settings UI)
- Added X-Content-Hash header support for remote Docker scenarios
- Added "Load from Server" button to sync settings from server

### Documentation
- Updated README with Docker deployment, standalone mode, and MCP server sections
- Added comprehensive [docker/README.md](docker/README.md) with configuration and security guidance
- Updated SECURITY.md with encrypted API key storage details and Docker security considerations
- Enhanced PRIVACY.md with network deployment security section
- Added v1.2.0 and v1.1.0 changelog entries

### Dependencies
- Added `mcp==1.0.0` and `cryptography==41.0.0` to requirements
- Updated CI documentation to reference ruff linting

### Security
- API keys encrypted using Fernet before storing in config file
- `/settings/sync` endpoint returns unmasked keys for Lightroom sync (network security note added)
- `/stats` and `GET /settings` endpoints mask API keys to last 4 characters
- Encryption key stored with restrictive file permissions (0600)