### PR TITLE
Add patrol time window settings and env var config

### DIFF
--- a/server/config.py
+++ b/server/config.py
@@ -60,6 +60,8 @@ config = {
     "patrol_folders": [],       # list of {"path": str, "recursive": bool}
     "patrol_interval_minutes": 5,
     "patrol_batch_size": 10,    # photos to process per batch before checking for interrupts
+    "patrol_start_time": "",    # HH:MM 24h format, empty = no restriction
+    "patrol_end_time": "",      # HH:MM 24h format, empty = no restriction
 }
 
 VERSION = "1.2.0"
@@ -104,9 +106,68 @@ def save_config():
             logger.info(f"Config saved to {path}")
 
 
+# Mapping from environment variable names to config keys and their types.
+# Types: str, int, bool
+_ENV_MAP = {
+    "INDEX_FOLDER":             ("index_folder", str),
+    "VISION_MODE":              ("vision_mode", str),
+    "OLLAMA_VISION_ENDPOINT":   ("ollama_vision_endpoint", str),
+    "OLLAMA_VISION_MODEL":      ("ollama_vision_model", str),
+    "OPENAI_VISION_API_KEY":    ("openai_vision_api_key", str),
+    "OPENAI_VISION_MODEL":      ("openai_vision_model", str),
+    "CLAUDE_VISION_API_KEY":    ("claude_vision_api_key", str),
+    "CLAUDE_VISION_MODEL":      ("claude_vision_model", str),
+    "EMBED_MODE":               ("embed_mode", str),
+    "OLLAMA_EMBED_ENDPOINT":    ("ollama_embed_endpoint", str),
+    "OLLAMA_EMBED_MODEL":       ("ollama_embed_model", str),
+    "OPENAI_EMBED_API_KEY":     ("openai_embed_api_key", str),
+    "OPENAI_EMBED_MODEL":       ("openai_embed_model", str),
+    "VOYAGE_EMBED_API_KEY":     ("voyage_embed_api_key", str),
+    "VOYAGE_EMBED_MODEL":       ("voyage_embed_model", str),
+    "SEARCH_MAX_RESULTS":       ("search_max_results", int),
+    "SEARCH_RELEVANCE":         ("search_relevance", int),
+    "THUMBNAIL_STORE_SIZE":     ("thumbnail_store_size", int),
+    "STRIP_GPS_FOR_CLOUD":      ("strip_gps_for_cloud", bool),
+    "DEBUG_LOGGING":            ("debug_logging", bool),
+    "PATROL_ENABLED":           ("patrol_enabled", bool),
+    "PATROL_INTERVAL_MINUTES":  ("patrol_interval_minutes", int),
+    "PATROL_BATCH_SIZE":        ("patrol_batch_size", int),
+    "PATROL_START_TIME":        ("patrol_start_time", str),
+    "PATROL_END_TIME":          ("patrol_end_time", str),
+}
+
+
+def _apply_env_overrides():
+    """Apply environment variables to config as defaults (before JSON load)."""
+    applied = []
+    for env_name, (cfg_key, typ) in _ENV_MAP.items():
+        val = os.environ.get(env_name)
+        if not val:
+            continue
+        if typ is bool:
+            config[cfg_key] = val.lower() in ("true", "1", "yes")
+        elif typ is int:
+            try:
+                config[cfg_key] = int(val)
+            except ValueError:
+                logger.warning(f"Invalid integer for {env_name}: {val}")
+                continue
+        else:
+            config[cfg_key] = val
+        applied.append(env_name)
+    if applied:
+        logger.info(f"Config from environment: {', '.join(applied)}")
+
+
 def load_config():
-    """Load config from disk. Encrypted API key fields are decrypted."""
+    """Load config from disk. Encrypted API key fields are decrypted.
+
+    Precedence (highest wins): JSON config file > environment variables > defaults.
+    """
     with _config_lock:
+        # Apply environment variables over hardcoded defaults
+        _apply_env_overrides()
+
         home_config = os.path.join(str(Path.home()), ".lrcembedindex_last_config.json")
         if os.path.exists(home_config):
             with open(home_config, "r") as f:
@@ -128,6 +189,11 @@ def load_config():
                     config.update(saved)
                 logger.info(f"Loaded config from {home_config}")
                 return True
+
+        # No JSON config found — env overrides are the active config
+        if config.get("index_folder"):
+            logger.info("Config initialized from environment variables")
+            return True
         return False
 
 

--- a/server/routes.py
+++ b/server/routes.py
@@ -2,6 +2,7 @@ import json
 import logging
 import subprocess
 import tempfile
+import threading
 import time
 import os
 import sys
@@ -81,13 +82,16 @@ def with_patrol_interrupt(f):
 
 
 @api.after_request
-def add_cors_headers(response):
-    """Restrict cross-origin requests to localhost only."""
+def add_headers(response):
+    """Add CORS and cache-control headers."""
     origin = request.headers.get("Origin", "")
     if origin.startswith("http://localhost:") or origin.startswith("http://127.0.0.1:"):
         response.headers["Access-Control-Allow-Origin"] = origin
         response.headers["Access-Control-Allow-Headers"] = "Content-Type"
         response.headers["Access-Control-Allow-Methods"] = "GET, POST, DELETE, OPTIONS"
+    # Prevent browser from caching JSON API responses
+    if response.content_type and "json" in response.content_type:
+        response.headers["Cache-Control"] = "no-store"
     return response
 
 
@@ -553,6 +557,20 @@ def update_settings():
             config["patrol_interval_minutes"] = max(1, int(data["patrol_interval_minutes"]))
         if "patrol_batch_size" in data:
             config["patrol_batch_size"] = max(1, int(data["patrol_batch_size"]))
+        for key in ("patrol_start_time", "patrol_end_time"):
+            if key in data:
+                val = (data[key] or "").strip()
+                if val:
+                    try:
+                        parts = val.split(":")
+                        h, m = int(parts[0]), int(parts[1])
+                        if not (0 <= h <= 23 and 0 <= m <= 59):
+                            raise ValueError
+                        val = f"{h:02d}:{m:02d}"
+                    except (ValueError, IndexError, AttributeError):
+                        return jsonify({"status": "error",
+                                        "message": f"Invalid time format for {key}: '{data[key]}'"}), 400
+                config[key] = val
 
         save_config()
         save_last_config_pointer()
@@ -577,60 +595,102 @@ def update_settings():
 
 _stats_cache = None
 _stats_cache_time = 0
-_STATS_CACHE_TTL = 60  # seconds
+_stats_computing = False
+_stats_lock = threading.Lock()
+_STATS_CACHE_TTL = 300  # seconds
 
 
 def invalidate_stats_cache():
     """Call after indexing or deleting photos to force a fresh stats computation."""
-    global _stats_cache, _stats_cache_time
-    _stats_cache = None
+    global _stats_cache_time
     _stats_cache_time = 0
+    _trigger_stats_refresh()
+
+
+def _compute_stats_background():
+    """Compute stats in a background thread and update the cache."""
+    global _stats_cache, _stats_cache_time, _stats_computing
+    try:
+        t_start = time.time()
+
+        meta_count = count_metadata_files()
+        meta_stats = collect_metadata_stats()
+        chroma_stats = get_chromadb_stats()
+        safe_config = {k: v for k, v in config.items() if "api_key" not in k}
+
+        elapsed = time.time() - t_start
+        logger.info(f"Stats computed in {elapsed:.1f}s")
+        result = {
+            "status": "ok",
+            "metadata": {
+                "total_files": meta_count,
+                "thumbnail_files": meta_stats.get("thumbnail_count", 0),
+                "vision_models": meta_stats.get("vision_models", {}),
+                "embed_models": meta_stats.get("embed_models", {}),
+                "oldest_entry": meta_stats.get("oldest_entry"),
+                "newest_entry": meta_stats.get("newest_entry"),
+            },
+            "chromadb": chroma_stats,
+            "config": safe_config,
+            "version": VERSION,
+            "elapsed": round(elapsed, 2),
+            "cached": False,
+        }
+        _stats_cache = result
+        _stats_cache_time = time.time()
+    except Exception:
+        logger.exception("Background stats computation failed")
+    finally:
+        with _stats_lock:
+            _stats_computing = False
+
+
+def _trigger_stats_refresh():
+    """Kick off a background stats computation if one isn't already running."""
+    global _stats_computing
+    with _stats_lock:
+        if _stats_computing:
+            return
+        _stats_computing = True
+    threading.Thread(target=_compute_stats_background, daemon=True).start()
 
 
 def compute_stats_cached():
-    """Return stats dict, using a 60s TTL cache.
+    """Return stats dict, using a background-refreshed cache.
+
+    Never blocks for a full stats computation. If the cache is stale or empty,
+    triggers a background refresh and returns whatever is available (stale cache
+    or a placeholder).
 
     Shared by the /stats HTTP endpoint and the MCP get_stats tool.
     """
-    global _stats_cache, _stats_cache_time
     now = time.time()
+    stale = (now - _stats_cache_time) >= _STATS_CACHE_TTL
 
-    if _stats_cache and (now - _stats_cache_time) < _STATS_CACHE_TTL:
+    if stale:
+        _trigger_stats_refresh()
+
+    if _stats_cache:
         cached = dict(_stats_cache)
         cached["config"] = {k: v for k, v in config.items() if "api_key" not in k}
-        cached["elapsed"] = 0
         cached["cached"] = True
-        logger.debug("Stats served from cache")
+        cached["computing"] = _stats_computing
         return cached
 
-    t_start = time.time()
-
-    meta_count = count_metadata_files()
-    meta_stats = collect_metadata_stats()
-    chroma_stats = get_chromadb_stats()
-    safe_config = {k: v for k, v in config.items() if "api_key" not in k}
-
-    elapsed = time.time() - t_start
-    logger.info(f"Stats computed in {elapsed:.1f}s")
-    result = {
+    # No cache at all yet (first request after startup)
+    return {
         "status": "ok",
-        "metadata": {
-            "total_files": meta_count,
-            "thumbnail_files": meta_stats.get("thumbnail_count", 0),
-            "vision_models": meta_stats.get("vision_models", {}),
-            "embed_models": meta_stats.get("embed_models", {}),
-            "oldest_entry": meta_stats.get("oldest_entry"),
-            "newest_entry": meta_stats.get("newest_entry"),
-        },
-        "chromadb": chroma_stats,
-        "config": safe_config,
+        "metadata": {"total_files": 0, "thumbnail_files": 0,
+                      "vision_models": {}, "embed_models": {},
+                      "oldest_entry": None, "newest_entry": None},
+        "chromadb": {"current_model": "", "current_count": 0,
+                     "current_path": "", "all_stores": []},
+        "config": {k: v for k, v in config.items() if "api_key" not in k},
         "version": VERSION,
-        "elapsed": round(elapsed, 2),
+        "elapsed": 0,
         "cached": False,
+        "computing": True,
     }
-    _stats_cache = result
-    _stats_cache_time = t_start
-    return result
 
 
 @api.route("/stats", methods=["GET"])
@@ -784,7 +844,7 @@ def patrol_start():
     config["patrol_enabled"] = True
     save_config()
     save_last_config_pointer()
-    worker.start()
+    worker.start(force=True)
     return jsonify({"status": "ok", "patrol": worker.get_status()})
 
 

--- a/server/templates/settings.html
+++ b/server/templates/settings.html
@@ -138,7 +138,8 @@
     background: #2a2a2a; border: 1px solid #444; border-radius: 6px;
     color: #aaa; cursor: pointer;
   }
-  .patrol-controls button:hover { border-color: #6b8afd; color: #6b8afd; }
+  .patrol-controls button:hover:not(:disabled) { border-color: #6b8afd; color: #6b8afd; }
+  .patrol-controls button:disabled { opacity: 0.4; cursor: not-allowed; }
 
   .loading { text-align: center; padding: 3rem; color: #666; }
 
@@ -370,6 +371,16 @@ function renderForm() {
       <input type="number" id="patrol_batch_size" value="${c.patrol_batch_size || 10}" min="1" max="100">
     </div>
     <div class="field">
+      <label class="field-label">Active Hours (leave empty for always)</label>
+      <div class="field-row">
+        <input type="text" id="patrol_start_time" value="${esc(c.patrol_start_time || '')}" placeholder="HH:MM" maxlength="5" style="width:80px;text-align:center">
+        <span style="color:#888;font-size:0.85rem">to</span>
+        <input type="text" id="patrol_end_time" value="${esc(c.patrol_end_time || '')}" placeholder="HH:MM" maxlength="5" style="width:80px;text-align:center">
+        <button class="reveal-btn" onclick="document.getElementById('patrol_start_time').value='';document.getElementById('patrol_end_time').value=''">Clear</button>
+      </div>
+      <div style="font-size:0.7rem;color:#666;margin-top:0.25rem">24h format, e.g. 08:00 to 18:00. Overnight windows supported (e.g. 22:00 to 06:00)</div>
+    </div>
+    <div class="field">
       <label class="field-label">Watched Folders</label>
       <div id="folder_list" class="folder-list">
         ${folders.map((f, i) => folderRow(f, i)).join('')}
@@ -377,6 +388,7 @@ function renderForm() {
       <button class="add-btn" onclick="addFolder()">+ Add Folder</button>
     </div>
     <div id="patrol_status_area"></div>
+    <div id="patrol_msg" style="font-size:0.8rem;margin-top:0.4rem;min-height:1.2em"></div>
   </div>`;
 
   // Save
@@ -501,6 +513,8 @@ async function saveSettings() {
     patrol_enabled: val('patrol_enabled'),
     patrol_interval_minutes: val('patrol_interval_minutes'),
     patrol_batch_size: val('patrol_batch_size'),
+    patrol_start_time: val('patrol_start_time'),
+    patrol_end_time: val('patrol_end_time'),
     patrol_folders: collectFolders(),
   };
 
@@ -544,19 +558,24 @@ async function loadPatrolStatus() {
     const data = await resp.json();
     if (data.status !== 'ok') return;
     const s = data.patrol;
+    const running = s.running;
+    const stateColor = running ? (s.state === 'scanning' ? '#4ade80' : '#6b8afd') : '#888';
+    const stateText = running
+      ? (s.state === 'scanning' ? 'scanning' : s.state === 'waiting' ? 'waiting' : s.state === 'paused' ? 'paused' : 'running (idle)')
+      : (s.state || 'stopped');
     area.innerHTML = `
       <div class="patrol-status">
-        <span class="status-label">Patrol Status:</span>
-        <span class="status-value">${esc(s.state || 'unknown')}</span>
+        <span class="status-label">Patrol:</span>
+        <span class="status-value" style="color:${stateColor}">${esc(stateText)}${s.waiting_reason ? ' (' + esc(s.waiting_reason) + ')' : ''}</span>
         ${s.files_processed != null ? ` | <span class="status-label">Processed:</span> <span class="status-value">${s.files_processed}</span>` : ''}
         ${s.files_remaining != null ? ` | <span class="status-label">Remaining:</span> <span class="status-value">${s.files_remaining}</span>` : ''}
         ${s.current_file ? ` | <span class="status-label">Current:</span> <span class="status-value">${esc(s.current_file.split('/').pop())}</span>` : ''}
         ${s.last_scan_time ? ` | <span class="status-label">Last scan:</span> <span class="status-value">${esc(s.last_scan_time)}</span>` : ''}
       </div>
       <div class="patrol-controls">
-        <button onclick="patrolAction('start')">Start</button>
-        <button onclick="patrolAction('pause')">Pause</button>
-        <button onclick="patrolAction('stop')">Stop</button>
+        <button onclick="patrolAction('start')" ${running && s.state !== 'paused' ? 'disabled' : ''}>Start</button>
+        <button onclick="patrolAction('pause')" ${!running || s.state === 'paused' ? 'disabled' : ''}>Pause</button>
+        <button onclick="patrolAction('stop')" ${!running ? 'disabled' : ''}>Stop</button>
       </div>
     `;
   } catch (e) {
@@ -565,10 +584,28 @@ async function loadPatrolStatus() {
 }
 
 async function patrolAction(action) {
+  const area = document.getElementById('patrol_status_area');
+  if (area) area.querySelectorAll('.patrol-controls button').forEach(b => b.disabled = true);
   try {
-    await fetch('/patrol/' + action, { method: 'POST' });
-    setTimeout(loadPatrolStatus, 500);
-  } catch (e) {}
+    const resp = await fetch('/patrol/' + action, { method: 'POST' });
+    const data = await resp.json();
+    if (data.status !== 'ok') {
+      showPatrolMsg(data.message || 'Action failed', true);
+    } else {
+      showPatrolMsg(action.charAt(0).toUpperCase() + action.slice(1) + ' successful');
+    }
+  } catch (e) {
+    showPatrolMsg('Request failed: ' + e.message, true);
+  }
+  setTimeout(loadPatrolStatus, 500);
+}
+
+function showPatrolMsg(text, isError) {
+  const el = document.getElementById('patrol_msg');
+  if (!el) return;
+  el.style.color = isError ? '#f87171' : '#4ade80';
+  el.textContent = text;
+  setTimeout(() => { el.textContent = ''; }, 4000);
 }
 
 function esc(s) {

--- a/server/templates/stats.html
+++ b/server/templates/stats.html
@@ -113,9 +113,15 @@
 <script>
 const contentEl = document.getElementById('content');
 
+let refreshTimer = null;
+
 async function loadStats() {
   try {
     const resp = await fetch('/stats');
+    if (!resp.ok) {
+      contentEl.innerHTML = `<div class="error">Server returned HTTP ${resp.status}</div>`;
+      return;
+    }
     const data = await resp.json();
 
     if (data.status !== 'ok') {
@@ -132,6 +138,11 @@ async function loadStats() {
     const cfg = data.config || {};
 
     let html = '';
+
+    // Computing banner
+    if (data.computing) {
+      html += '<div class="loading">Computing stats in background\u2026</div>';
+    }
 
     // Summary cards
     html += '<div class="cards">';
@@ -210,6 +221,12 @@ async function loadStats() {
 
     contentEl.innerHTML = html;
 
+    // Auto-refresh while stats are being computed
+    clearTimeout(refreshTimer);
+    if (data.computing) {
+      refreshTimer = setTimeout(loadStats, 5000);
+    }
+
   } catch (err) {
     contentEl.innerHTML = `<div class="error">Error: ${escapeHtml(err.message)}</div>`;
   }
@@ -226,7 +243,7 @@ function card(label, value, subHtml) {
 function formatDate(iso) {
   try {
     const d = new Date(iso);
-    return d.toLocaleDateString() + ' ' + d.toLocaleTimeString([], {hour: '2-digit', minute: '2-digit'});
+    return d.toLocaleDateString() + ' ' + d.toLocaleTimeString(undefined, {hour: '2-digit', minute: '2-digit'});
   } catch (e) { return iso; }
 }
 


### PR DESCRIPTION
## Summary
- Add patrol_start_time/patrol_end_time config fields and Settings UI inputs with validation
- Add environment variable overrides for all config keys (for Docker deployment)
- Refactor stats computation to non-blocking background refresh with TTL cache
- Improve patrol status display with color-coded states and disabled button logic

## Test plan
- [ ] Set patrol active hours in Settings UI and verify they save/load correctly
- [ ] Enter invalid time format and confirm error is returned
- [ ] Verify stats page loads instantly with background refresh
- [ ] Confirm patrol buttons are correctly enabled/disabled based on state

🤖 Generated with [Claude Code](https://claude.com/claude-code)