### PR TITLE
Add configurable scan order to auto patrol (newest-first by default)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -68,6 +68,10 @@ PATROL_ENABLED=true
 PATROL_INTERVAL_MINUTES=5
 PATROL_BATCH_SIZE=10
 
+# Order photos are processed in, by file modification time.
+# newest = newest files first, oldest = oldest first, name = filename A->Z
+PATROL_SCAN_ORDER=newest
+
 # Time window (24h HH:MM format). Patrol only runs between start and end.
 # Supports overnight windows (e.g. 22:00 to 06:00).
 # Leave both empty for no restriction.

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -44,6 +44,7 @@ services:
       - PATROL_BATCH_SIZE=${PATROL_BATCH_SIZE:-}
       - PATROL_START_TIME=${PATROL_START_TIME:-}
       - PATROL_END_TIME=${PATROL_END_TIME:-}
+      - PATROL_SCAN_ORDER=${PATROL_SCAN_ORDER:-}
 
 volumes:
   lrcembedindex-key:

--- a/server/config.py
+++ b/server/config.py
@@ -62,6 +62,7 @@ config = {
     "patrol_batch_size": 10,    # photos to process per batch before checking for interrupts
     "patrol_start_time": "",    # HH:MM 24h format, empty = no restriction
     "patrol_end_time": "",      # HH:MM 24h format, empty = no restriction
+    "patrol_scan_order": "newest",  # order to process photos: newest | oldest | name
 }
 
 VERSION = "1.2.0"
@@ -134,6 +135,7 @@ _ENV_MAP = {
     "PATROL_BATCH_SIZE":        ("patrol_batch_size", int),
     "PATROL_START_TIME":        ("patrol_start_time", str),
     "PATROL_END_TIME":          ("patrol_end_time", str),
+    "PATROL_SCAN_ORDER":        ("patrol_scan_order", str),
 }
 
 

--- a/server/patrol.py
+++ b/server/patrol.py
@@ -23,7 +23,8 @@ from vectorstore import upsert_photo
 from vision import describe_image
 from embedding import get_embedding
 from helpers import exif_to_text, compute_content_hash, resize_thumbnail_bytes
-from photo_utils import find_photos, make_thumbnail, extract_exif, extract_exif_raw, RAW_EXTENSIONS
+from photo_utils import (find_photos, order_photos, make_thumbnail,
+                         extract_exif, extract_exif_raw, RAW_EXTENSIONS)
 
 logger = logging.getLogger(__name__)
 
@@ -275,6 +276,12 @@ class PatrolWorker:
         for photo_path in all_photos:
             if self._should_index(photo_path):
                 to_index.append(photo_path)
+
+        # Order the work list according to the configured scan order. This only
+        # affects processing order, not which photos are indexed. "name" keeps
+        # the filename-sorted discovery order from find_photos().
+        scan_order = config.get("patrol_scan_order", "newest")
+        to_index = order_photos(to_index, scan_order)
 
         self._files_remaining = len(to_index)
         self._total_discovered = len(all_photos)

--- a/server/photo_utils.py
+++ b/server/photo_utils.py
@@ -35,6 +35,33 @@ def find_photos(directory, extensions=None):
     return photos
 
 
+# Valid values for photo scan ordering (see order_photos / patrol_scan_order).
+SCAN_ORDERS = ("newest", "oldest", "name")
+
+
+def _file_mtime(path):
+    """File modification time used as a sort key. Missing or unreadable files
+    sort as oldest (0.0) so a race with deletion never breaks the scan."""
+    try:
+        return os.path.getmtime(path)
+    except OSError:
+        return 0.0
+
+
+def order_photos(photos, scan_order):
+    """Return photos ordered per scan_order.
+
+    "newest" / "oldest" sort by file modification time (descending / ascending).
+    "name" (or any unknown value) preserves the incoming filename-sorted order.
+    Sorts a copy so the caller's list is left untouched.
+    """
+    if scan_order == "newest":
+        return sorted(photos, key=_file_mtime, reverse=True)
+    if scan_order == "oldest":
+        return sorted(photos, key=_file_mtime)
+    return list(photos)
+
+
 def make_thumbnail_pillow(image_path):
     """Generate a JPEG thumbnail using Pillow (for JPEG, PNG, TIFF)."""
     from PIL import Image

--- a/server/routes.py
+++ b/server/routes.py
@@ -26,6 +26,7 @@ from vectorstore import (init_chromadb, upsert_photo, search_photos,
 from vision import describe_image
 from embedding import get_embedding
 from helpers import exif_to_text, compute_content_hash, resize_thumbnail_bytes
+from photo_utils import SCAN_ORDERS
 
 logger = logging.getLogger(__name__)
 
@@ -563,6 +564,12 @@ def update_settings():
             config["patrol_interval_minutes"] = max(1, int(data["patrol_interval_minutes"]))
         if "patrol_batch_size" in data:
             config["patrol_batch_size"] = max(1, int(data["patrol_batch_size"]))
+        if "patrol_scan_order" in data:
+            order = str(data["patrol_scan_order"])
+            if order not in SCAN_ORDERS:
+                return jsonify({"status": "error",
+                                "message": f"Invalid patrol_scan_order: '{order}'"}), 400
+            config["patrol_scan_order"] = order
         for key in ("patrol_start_time", "patrol_end_time"):
             if key in data:
                 val = (data[key] or "").strip()

--- a/server/templates/patrol.html
+++ b/server/templates/patrol.html
@@ -352,6 +352,8 @@ async function loadStatus() {
     const tw = (cfg.patrol_start_time && cfg.patrol_end_time) ? cfg.patrol_start_time + ' - ' + cfg.patrol_end_time : 'unrestricted';
     html += `<div class="card"><div class="card-label">Time Window</div><div class="card-value" style="font-size:1rem">${esc(tw)}</div></div>`;
     html += `<div class="card"><div class="card-label">Batch Size</div><div class="card-value" style="font-size:1.2rem">${cfg.patrol_batch_size || '-'}</div></div>`;
+    const orderLabels = {newest: 'Newest first', oldest: 'Oldest first', name: 'Filename'};
+    html += `<div class="card"><div class="card-label">Scan Order</div><div class="card-value" style="font-size:1rem">${esc(orderLabels[cfg.patrol_scan_order] || 'Newest first')}</div></div>`;
     html += '</div>';
 
     contentEl.innerHTML = html;

--- a/server/templates/settings.html
+++ b/server/templates/settings.html
@@ -372,6 +372,15 @@ function renderForm() {
       <input type="number" id="patrol_batch_size" value="${c.patrol_batch_size || 10}" min="1" max="100">
     </div>
     <div class="field">
+      <label class="field-label">Scan Order</label>
+      <select id="patrol_scan_order">
+        <option value="newest" ${(c.patrol_scan_order||'newest')==='newest'?'selected':''}>Newest files first</option>
+        <option value="oldest" ${c.patrol_scan_order==='oldest'?'selected':''}>Oldest files first</option>
+        <option value="name" ${c.patrol_scan_order==='name'?'selected':''}>Filename (A→Z)</option>
+      </select>
+      <div style="font-size:0.7rem;color:#666;margin-top:0.25rem">Order photos are processed in, by file modification time.</div>
+    </div>
+    <div class="field">
       <label class="field-label">Active Hours (leave empty for always)</label>
       <div class="field-row">
         <input type="text" id="patrol_start_time" value="${esc(c.patrol_start_time || '')}" placeholder="HH:MM" maxlength="5" style="width:80px;text-align:center">
@@ -514,6 +523,7 @@ async function saveSettings() {
     patrol_enabled: val('patrol_enabled'),
     patrol_interval_minutes: val('patrol_interval_minutes'),
     patrol_batch_size: val('patrol_batch_size'),
+    patrol_scan_order: val('patrol_scan_order'),
     patrol_start_time: val('patrol_start_time'),
     patrol_end_time: val('patrol_end_time'),
     patrol_folders: collectFolders(),

--- a/server/tests/test_order_photos.py
+++ b/server/tests/test_order_photos.py
@@ -1,0 +1,109 @@
+"""Tests for photo_utils.order_photos (patrol scan ordering).
+
+Exercises the real function against real files on disk with controlled
+modification times. No mocks. Run with: python3 -m pytest server/tests
+or standalone: python3 server/tests/test_order_photos.py
+"""
+
+import os
+import sys
+import tempfile
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from photo_utils import order_photos, _file_mtime, SCAN_ORDERS  # noqa: E402
+
+
+def _make_files(tmp):
+    """Create three files and stamp distinct mtimes.
+
+    b.jpg is newest, c.jpg middle, a.jpg oldest -- deliberately NOT matching
+    filename order so mtime vs name ordering are distinguishable.
+    """
+    paths = {}
+    for name, mtime in (("a.jpg", 1000), ("b.jpg", 3000), ("c.jpg", 2000)):
+        p = os.path.join(tmp, name)
+        with open(p, "w") as f:
+            f.write("x")
+        os.utime(p, (mtime, mtime))
+        paths[name] = p
+    # Discovery order is filename-sorted, as find_photos would return it.
+    return [paths["a.jpg"], paths["b.jpg"], paths["c.jpg"]]
+
+
+def test_newest_first():
+    with tempfile.TemporaryDirectory() as tmp:
+        files = _make_files(tmp)
+        result = order_photos(files, "newest")
+        assert [os.path.basename(p) for p in result] == ["b.jpg", "c.jpg", "a.jpg"]
+
+
+def test_oldest_first():
+    with tempfile.TemporaryDirectory() as tmp:
+        files = _make_files(tmp)
+        result = order_photos(files, "oldest")
+        assert [os.path.basename(p) for p in result] == ["a.jpg", "c.jpg", "b.jpg"]
+
+
+def test_name_preserves_discovery_order():
+    with tempfile.TemporaryDirectory() as tmp:
+        files = _make_files(tmp)
+        result = order_photos(files, "name")
+        assert result == files
+
+
+def test_unknown_order_preserves_discovery_order():
+    with tempfile.TemporaryDirectory() as tmp:
+        files = _make_files(tmp)
+        result = order_photos(files, "bogus-value")
+        assert result == files
+
+
+def test_does_not_mutate_input():
+    with tempfile.TemporaryDirectory() as tmp:
+        files = _make_files(tmp)
+        original = list(files)
+        order_photos(files, "newest")
+        assert files == original
+
+
+def test_empty_list():
+    assert order_photos([], "newest") == []
+    assert order_photos([], "name") == []
+
+
+def test_missing_file_sorts_as_oldest():
+    with tempfile.TemporaryDirectory() as tmp:
+        files = _make_files(tmp)
+        ghost = os.path.join(tmp, "deleted.jpg")  # never created
+        # A missing file (mtime 0.0) must sort last under "newest", first
+        # under "oldest", and must not raise.
+        newest = order_photos(files + [ghost], "newest")
+        assert os.path.basename(newest[-1]) == "deleted.jpg"
+        oldest = order_photos(files + [ghost], "oldest")
+        assert os.path.basename(oldest[0]) == "deleted.jpg"
+
+
+def test_file_mtime_missing_returns_zero():
+    assert _file_mtime("/no/such/path/xyz.jpg") == 0.0
+
+
+def test_scan_orders_constant():
+    assert SCAN_ORDERS == ("newest", "oldest", "name")
+
+
+if __name__ == "__main__":
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_")]
+    failed = 0
+    for t in tests:
+        try:
+            t()
+            print(f"PASS {t.__name__}")
+        except AssertionError as e:
+            failed += 1
+            print(f"FAIL {t.__name__}: {e}")
+        except Exception as e:  # noqa: BLE001
+            failed += 1
+            print(f"ERROR {t.__name__}: {type(e).__name__}: {e}")
+    print(f"\n{len(tests) - failed}/{len(tests)} passed")
+    sys.exit(1 if failed else 0)


### PR DESCRIPTION
## What

Adds a **Scan Order** setting to Auto Patrol so it can process the **newest photos first** (by file modification time). This is now the default. Options:

- **Newest first** (default) — by file mtime, descending
- **Oldest first** — by file mtime, ascending
- **Filename (A→Z)** — previous behavior

## Why

Previously patrol always processed photos in filename order within each folder, so newly added photos could wait behind the entire back-catalog before being indexed and made searchable. Newest-first surfaces recent photos soonest.

## Changes

- **`photo_utils.py`** — new `order_photos()` / `_file_mtime()` helpers + `SCAN_ORDERS` constant, placed beside `find_photos()` so ordering is reusable and unit-testable without importing patrol's heavy deps (chromadb, etc.).
- **`patrol.py`** — sorts the work list via `order_photos()` before processing. Affects processing *order* only, not *which* photos are indexed. `find_photos()` is untouched, so the batch CLI (`scan_and_index.py`) is unaffected.
- **`config.py`** — new `patrol_scan_order` default (`"newest"`) + `PATROL_SCAN_ORDER` env var.
- **`routes.py`** — whitelist-validates the setting against `SCAN_ORDERS` (returns 400 on an invalid value).
- **`settings.html`** — Scan Order dropdown. **`patrol.html`** — Scan Order status card.
- **`.env.example`** — documents `PATROL_SCAN_ORDER`.
- **`tests/test_order_photos.py`** — 9 tests exercising `order_photos` against real files with controlled mtimes (no mocks). All passing.

## Reviewer notes

- **Behavior change on upgrade:** default is `"newest"`, so existing installs switch from filename-order to newest-first. This is intended. Existing configs inherit the default via the `config.update()` merge — no migration needed.
- **Robustness:** a file deleted mid-sort returns mtime `0.0` (sorts as oldest) rather than raising; unknown/garbage values fall back to filename order. Python's stable sort keeps equal-mtime files in filename order (deterministic).
- **No starvation:** newest-first combined with the existing `_should_index` filter means each pass drains the newest unindexed files and later passes reach older ones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)