### PR TITLE
Support Nikon Z8/Z9 High Efficiency NEF via embedded preview fallback

### DIFF
--- a/server/generate_thumbnails.py
+++ b/server/generate_thumbnails.py
@@ -12,41 +12,17 @@ Usage:
 """
 
 import argparse
-import io
 import json
 import logging
 import os
 import sys
 
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from photo_utils import make_thumbnail  # noqa: E402
+
 logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
 logger = logging.getLogger(__name__)
-
-RAW_EXTENSIONS = {
-    ".arw", ".cr2", ".cr3", ".nef", ".orf", ".raf",
-    ".rw2", ".dng", ".pef", ".srw", ".x3f",
-}
-
-
-def make_thumbnail(image_path, max_size=512, quality=85):
-    """Generate a JPEG thumbnail from an image file."""
-    from PIL import Image
-
-    ext = os.path.splitext(image_path)[1].lower()
-    if ext in RAW_EXTENSIONS:
-        import rawpy
-
-        with rawpy.imread(image_path) as raw:
-            rgb = raw.postprocess(use_camera_wb=True, half_size=True)
-        img = Image.fromarray(rgb)
-    else:
-        img = Image.open(image_path)
-
-    img.thumbnail((max_size, max_size))
-    if img.mode not in ("RGB", "L"):
-        img = img.convert("RGB")
-    buf = io.BytesIO()
-    img.save(buf, format="JPEG", quality=quality)
-    return buf.getvalue()
 
 
 def thumbnail_path_for_metadata(json_path):

--- a/server/patrol.py
+++ b/server/patrol.py
@@ -389,7 +389,8 @@ class PatrolWorker:
         basename = os.path.basename(image_path)
         logger.info(f"Patrol indexing: {basename}")
 
-        # Generate thumbnail (skip photo if RAW format is unsupported, e.g. Nikon Z9 compressed)
+        # Generate thumbnail (skip photo only if both RAW decode and the
+        # embedded-preview fallback fail; see make_thumbnail_raw)
         try:
             jpeg_data = make_thumbnail(image_path)
         except Exception as e:

--- a/server/photo_utils.py
+++ b/server/photo_utils.py
@@ -62,39 +62,74 @@ def order_photos(photos, scan_order):
     return list(photos)
 
 
-def make_thumbnail_pillow(image_path):
+def _finish_thumbnail(img, max_size, quality):
+    """Resize a PIL image in place and encode it as JPEG bytes."""
+    img.thumbnail((max_size, max_size))
+    if img.mode not in ("RGB", "L"):
+        img = img.convert("RGB")
+    buf = io.BytesIO()
+    img.save(buf, format="JPEG", quality=quality)
+    return buf.getvalue()
+
+
+def make_thumbnail_pillow(image_path, max_size=MAX_THUMB_SIZE, quality=85):
     """Generate a JPEG thumbnail using Pillow (for JPEG, PNG, TIFF)."""
     from PIL import Image
 
     with Image.open(image_path) as img:
-        img.thumbnail((MAX_THUMB_SIZE, MAX_THUMB_SIZE))
-        if img.mode not in ("RGB", "L"):
-            img = img.convert("RGB")
-        buf = io.BytesIO()
-        img.save(buf, format="JPEG", quality=85)
-        return buf.getvalue()
+        return _finish_thumbnail(img, max_size, quality)
 
 
-def make_thumbnail_raw(image_path):
-    """Generate a JPEG thumbnail using rawpy (for RAW formats: NEF, ARW, CR2, etc.)."""
+def _embedded_preview_image(image_path):
+    """Open the camera-embedded preview of a RAW file as a PIL image.
+
+    Raises rawpy.LibRawError (or subclasses) when the file has no
+    extractable preview.
+    """
+    import rawpy
+    from PIL import Image, ImageOps
+
+    with rawpy.imread(image_path) as raw:
+        thumb = raw.extract_thumb()
+    if thumb.format == rawpy.ThumbFormat.JPEG:
+        img = Image.open(io.BytesIO(thumb.data))
+        img.load()
+        # Previews are stored unrotated; honor their EXIF orientation tag
+        # so portrait shots don't come out sideways (no-op when absent).
+        return ImageOps.exif_transpose(img)
+    return Image.fromarray(thumb.data)
+
+
+def make_thumbnail_raw(image_path, max_size=MAX_THUMB_SIZE, quality=85):
+    """Generate a JPEG thumbnail using rawpy (for RAW formats: NEF, ARW, CR2, etc.).
+
+    When LibRaw cannot decode the sensor data (e.g. Nikon Z8/Z9/Zf High
+    Efficiency NEF, whose TicoRAW compression is patent-encumbered), falls
+    back to the camera-embedded JPEG preview, which is full-size on those
+    bodies and plenty for a thumbnail.
+    """
     import rawpy
     from PIL import Image
 
-    with rawpy.imread(image_path) as raw:
-        rgb = raw.postprocess(use_camera_wb=True, half_size=True)
-    img = Image.fromarray(rgb)
-    img.thumbnail((MAX_THUMB_SIZE, MAX_THUMB_SIZE))
-    buf = io.BytesIO()
-    img.save(buf, format="JPEG", quality=85)
-    return buf.getvalue()
+    try:
+        with rawpy.imread(image_path) as raw:
+            rgb = raw.postprocess(use_camera_wb=True, half_size=True)
+        img = Image.fromarray(rgb)
+    except rawpy.LibRawError:
+        logger.info(
+            f"LibRaw cannot decode {os.path.basename(image_path)}; "
+            f"using embedded preview"
+        )
+        img = _embedded_preview_image(image_path)
+    return _finish_thumbnail(img, max_size, quality)
 
 
-def make_thumbnail(image_path):
+def make_thumbnail(image_path, max_size=MAX_THUMB_SIZE, quality=85):
     """Generate a JPEG thumbnail, dispatching to rawpy for RAW files."""
     ext = os.path.splitext(image_path)[1].lower()
     if ext in RAW_EXTENSIONS:
-        return make_thumbnail_raw(image_path)
-    return make_thumbnail_pillow(image_path)
+        return make_thumbnail_raw(image_path, max_size=max_size, quality=quality)
+    return make_thumbnail_pillow(image_path, max_size=max_size, quality=quality)
 
 
 def extract_exif(image_path):

--- a/server/tests/test_make_thumbnail.py
+++ b/server/tests/test_make_thumbnail.py
@@ -1,0 +1,225 @@
+"""Tests for photo_utils thumbnail generation, including the embedded-preview
+fallback for RAW formats LibRaw cannot decode (e.g. Nikon Z8/Z9 HE* NEF).
+
+Pillow code paths run against real image files generated on disk. The RAW
+fallback logic is exercised with a stub rawpy module injected into
+sys.modules -- a real HE* NEF cannot be committed to the repo (file size,
+copyright) and rawpy is not installed in every dev environment. Set
+LRCEI_TEST_RAW_FILE=/path/to/file.nef to additionally run the real
+end-to-end fallback against an actual RAW file with the real rawpy.
+
+Run with: python3 -m pytest server/tests
+or standalone: python3 server/tests/test_make_thumbnail.py
+"""
+
+import io
+import os
+import sys
+import tempfile
+import types
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import photo_utils  # noqa: E402
+from photo_utils import (  # noqa: E402
+    make_thumbnail, make_thumbnail_pillow, MAX_THUMB_SIZE,
+)
+
+from PIL import Image  # noqa: E402
+
+
+def _write_image(path, size=(2000, 1500), mode="RGB", fmt=None):
+    Image.new(mode, size, color=(200, 120, 40) if mode == "RGB" else None).save(
+        path, format=fmt)
+    return path
+
+
+def _assert_valid_jpeg(data, max_size):
+    img = Image.open(io.BytesIO(data))
+    assert img.format == "JPEG"
+    assert max(img.size) <= max_size
+    return img
+
+
+# ---------------------------------------------------------------------------
+# Pillow path (real files, no stubs)
+# ---------------------------------------------------------------------------
+
+def test_jpeg_thumbnail_resizes_to_default_max():
+    with tempfile.TemporaryDirectory() as tmp:
+        p = _write_image(os.path.join(tmp, "photo.jpg"))
+        data = make_thumbnail(p)
+        img = _assert_valid_jpeg(data, MAX_THUMB_SIZE)
+        # 2000x1500 shrinks to exactly 1024 on the long edge
+        assert max(img.size) == MAX_THUMB_SIZE
+
+
+def test_custom_max_size_and_small_image_not_upscaled():
+    with tempfile.TemporaryDirectory() as tmp:
+        p = _write_image(os.path.join(tmp, "photo.jpg"))
+        data = make_thumbnail(p, max_size=512)
+        _assert_valid_jpeg(data, 512)
+
+        small = _write_image(os.path.join(tmp, "small.jpg"), size=(100, 80))
+        data = make_thumbnail(small)
+        img = Image.open(io.BytesIO(data))
+        assert img.size == (100, 80)
+
+
+def test_rgba_png_converted_to_rgb():
+    with tempfile.TemporaryDirectory() as tmp:
+        p = os.path.join(tmp, "photo.png")
+        Image.new("RGBA", (300, 200), (10, 20, 30, 128)).save(p)
+        data = make_thumbnail(p)
+        img = _assert_valid_jpeg(data, MAX_THUMB_SIZE)
+        assert img.mode == "RGB"
+
+
+def test_dispatch_uses_pillow_for_non_raw():
+    with tempfile.TemporaryDirectory() as tmp:
+        p = _write_image(os.path.join(tmp, "photo.jpg"))
+        assert make_thumbnail(p) == make_thumbnail_pillow(p)
+
+
+def test_generate_thumbnails_uses_shared_impl():
+    import generate_thumbnails
+    assert generate_thumbnails.make_thumbnail is photo_utils.make_thumbnail
+
+
+# ---------------------------------------------------------------------------
+# RAW fallback path (stub rawpy -- see module docstring for why)
+# ---------------------------------------------------------------------------
+
+def _make_stub_rawpy(thumb_format=None, thumb_data=None):
+    """Build a minimal rawpy stand-in whose postprocess always fails with
+    LibRawError (simulating an HE* NEF) and whose extract_thumb returns the
+    given preview."""
+    mod = types.ModuleType("rawpy")
+
+    class LibRawError(Exception):
+        pass
+
+    class ThumbFormat:
+        JPEG = "jpeg"
+        BITMAP = "bitmap"
+
+    class _Raw:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            return False
+
+        def postprocess(self, **kwargs):
+            raise LibRawError("Unsupported file format or not RAW file")
+
+        def extract_thumb(self):
+            return types.SimpleNamespace(format=thumb_format, data=thumb_data)
+
+    mod.LibRawError = LibRawError
+    mod.ThumbFormat = ThumbFormat
+    mod.imread = lambda path: _Raw()
+    return mod
+
+
+def _with_stub_rawpy(stub, fn):
+    saved = sys.modules.get("rawpy")
+    sys.modules["rawpy"] = stub
+    try:
+        return fn()
+    finally:
+        if saved is None:
+            del sys.modules["rawpy"]
+        else:
+            sys.modules["rawpy"] = saved
+
+
+def _jpeg_bytes(size=(3000, 2000)):
+    buf = io.BytesIO()
+    Image.new("RGB", size, (90, 140, 60)).save(buf, format="JPEG")
+    return buf.getvalue()
+
+
+def test_raw_fallback_to_embedded_jpeg_preview():
+    """postprocess raising LibRawError must fall back to the embedded JPEG."""
+    stub = _make_stub_rawpy(thumb_format="jpeg", thumb_data=_jpeg_bytes())
+
+    def run():
+        data = make_thumbnail("/nonexistent/fake.nef")
+        img = _assert_valid_jpeg(data, MAX_THUMB_SIZE)
+        assert max(img.size) == MAX_THUMB_SIZE
+
+    _with_stub_rawpy(stub, run)
+
+
+def test_raw_fallback_to_bitmap_preview():
+    """A BITMAP-format preview must be converted via Image.fromarray."""
+    try:
+        import numpy as np
+    except ImportError:
+        return  # numpy not available; production always has it via chromadb
+    arr = np.zeros((200, 300, 3), dtype=np.uint8)
+    stub = _make_stub_rawpy(thumb_format="bitmap", thumb_data=arr)
+
+    def run():
+        data = make_thumbnail("/nonexistent/fake.nef")
+        img = Image.open(io.BytesIO(data))
+        assert img.size == (300, 200)
+
+    _with_stub_rawpy(stub, run)
+
+
+def test_raw_non_libraw_errors_still_propagate():
+    """Only LibRaw decode errors trigger the fallback; e.g. a missing file
+    (OSError from the stub's imread) must still raise so callers skip it."""
+    stub = _make_stub_rawpy()
+
+    def imread(path):
+        raise OSError("no such file")
+
+    stub.imread = imread
+
+    def run():
+        try:
+            make_thumbnail("/nonexistent/fake.nef")
+        except OSError:
+            return
+        raise AssertionError("expected OSError to propagate")
+
+    _with_stub_rawpy(stub, run)
+
+
+# ---------------------------------------------------------------------------
+# Optional real-file integration test (real rawpy, real RAW file)
+# ---------------------------------------------------------------------------
+
+def test_real_raw_file_if_configured():
+    """End-to-end with the real rawpy against a real RAW file.
+
+    Skipped unless LRCEI_TEST_RAW_FILE points at an existing RAW file.
+    Use a Nikon Z8/Z9 High Efficiency NEF to exercise the fallback path.
+    """
+    path = os.environ.get("LRCEI_TEST_RAW_FILE")
+    if not path or not os.path.exists(path):
+        return
+    data = make_thumbnail(path)
+    img = _assert_valid_jpeg(data, MAX_THUMB_SIZE)
+    assert min(img.size) > 0
+    print(f"  real RAW thumbnail: {img.size}, {len(data)} bytes")
+
+
+if __name__ == "__main__":
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_")]
+    failed = 0
+    for t in tests:
+        try:
+            t()
+            print(f"PASS {t.__name__}")
+        except AssertionError as e:
+            failed += 1
+            print(f"FAIL {t.__name__}: {e}")
+        except Exception as e:  # noqa: BLE001
+            failed += 1
+            print(f"ERROR {t.__name__}: {type(e).__name__}: {e}")
+    print(f"\n{len(tests) - failed}/{len(tests)} passed")
+    sys.exit(1 if failed else 0)


### PR DESCRIPTION
## What changed

- **`server/photo_utils.py`** — `make_thumbnail_raw` now falls back to the camera-embedded JPEG preview (via rawpy's `extract_thumb()`) when the full RAW decode raises `rawpy.LibRawError`. The preview's EXIF orientation tag is applied so portrait shots aren't rotated sideways. All thumbnail helpers gained `max_size`/`quality` parameters.
- **`server/generate_thumbnails.py`** — dropped its duplicated private `make_thumbnail` and now imports the shared `photo_utils` implementation (inherits the fallback; its 512px CLI default is preserved via `--size`).
- **`server/patrol.py`** — updated the stale "skip Nikon Z9 compressed" comment.
- **`server/tests/test_make_thumbnail.py`** (new) — 9 tests: real-file Pillow paths, stubbed-rawpy fallback paths (a real NEF can't live in the repo), and an integration test gated on `LRCEI_TEST_RAW_FILE` for running against a real RAW file.

## Why

LibRaw cannot decode High Efficiency (HE/HE\*) compressed NEFs from the Nikon Z8/Z9/Zf — their TicoRAW compression is patent-encumbered ([LibRaw discussion](https://www.libraw.org/node/2766)) — so patrol and scan_and_index skipped every such photo. The NEF container still holds a full-size camera-rendered JPEG preview (5392×3592 on the Z8), which is more than enough for the 1024px thumbnails the vision/embedding pipeline needs.

## Notes for reviewers

- The fallback only runs where the code previously failed and skipped the photo; decodable RAW formats (lossless NEF, ARW, DNG, …) keep the unchanged full-decode path. Files with no readable preview still raise, preserving skip-and-log behavior in patrol.
- Only `rawpy.LibRawError` (and subclasses, e.g. `LibRawFileUnsupportedError`) triggers the fallback; other errors such as `OSError` still propagate (covered by a test).
- Verified end-to-end against real Z8 HE\* NEFs with rawpy 0.27.0 / LibRaw 0.22.1: `postprocess` fails, the fallback produces a correctly oriented, correct-color 1024px thumbnail. A decodable Leica DNG was regression-tested through the unchanged path.
- No dependency or Dockerfile changes required — `extract_thumb` is available well within the pinned `rawpy>=0.19`. Deployment needs the usual image rebuild to take effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)